### PR TITLE
refactor: remove upgrade metadata and optimize addon matching

### DIFF
--- a/docs/addon-database.md
+++ b/docs/addon-database.md
@@ -12,8 +12,7 @@ The addon database is an embedded JSON file (`internal/addon/k8s_universal_addon
       "project_url": "https://cert-manager.io",
       "repository": "https://github.com/cert-manager/cert-manager",
       "compatibility_matrix_url": "https://cert-manager.io/docs/releases/",
-      "changelog_location": "https://github.com/cert-manager/cert-manager/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/cert-manager/cert-manager/releases"
     }
   ],
   "metadata": {}
@@ -29,16 +28,6 @@ The addon database is an embedded JSON file (`internal/addon/k8s_universal_addon
 | `repository` | Yes | Source code repository |
 | `compatibility_matrix_url` | Yes | Page containing K8s version compatibility data |
 | `changelog_location` | Yes | Release notes or changelog URL |
-| `upgrade_path_type` | Yes | How the addon is typically upgraded |
-
-### Upgrade path types
-
-| Type | Description |
-|------|-------------|
-| `Helm-driven` | Upgraded via Helm chart releases |
-| `Operator-managed` | Upgraded by an operator (CRD-based lifecycle) |
-| `Manual-manifest` | Applied via raw YAML manifests |
-| `Platform-managed` | Managed by the cloud provider (EKS, GKE addons) |
 
 ## Matching algorithm
 
@@ -81,7 +70,7 @@ The conversion is transparent — the database stores the human-readable GitHub 
 To add an addon to the database:
 
 1. Edit `internal/addon/k8s_universal_addons.json` and add an entry to the `addons` array
-2. Fill in all six fields — the most important is `compatibility_matrix_url`, which should point to a page with actual K8s version compatibility data (not a generic README)
+2. Fill in all five fields — the most important is `compatibility_matrix_url`, which should point to a page with actual K8s version compatibility data (not a generic README)
 3. Prefer these URL sources in order:
    - Dedicated compatibility or prerequisites page in official docs
    - Helm chart README with K8s version requirements

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -84,7 +84,7 @@ See [addon-database.md](addon-database.md) for the full process.
 
 Short version:
 
-1. Add entry to `internal/addon/k8s_universal_addons.json` with all six fields
+1. Add entry to `internal/addon/k8s_universal_addons.json` with all five fields
 2. `go build ./...` — verify JSON parses
 3. `make validate` — verify URLs are reachable and compatibility pages have K8s data
 4. `go test -v ./...` — all tests pass

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/qbandev/kaddons
 
 go 1.25.7
 
-require google.golang.org/genai v1.47.0
+require (
+	github.com/spf13/cobra v1.10.2
+	google.golang.org/genai v1.47.0
+)
 
 require (
 	cloud.google.com/go v0.116.0 // indirect
@@ -13,6 +16,8 @@ require (
 	github.com/google/s2a-go v0.1.8 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/net v0.47.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,7 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -44,8 +45,15 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.4 h1:XYIDZApgAnrN1c855gT
 github.com/googleapis/enterprise-certificate-proxy v0.3.4/go.mod h1:YKe7cfqYXjKGpGvmSg28/fFvhNzinZQm8DGnaburhGA=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -54,6 +62,7 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=

--- a/internal/addon/k8s_universal_addons.json
+++ b/internal/addon/k8s_universal_addons.json
@@ -5,5344 +5,4676 @@
       "project_url": "https://github.com/kubeflow/spark-operator",
       "repository": "https://github.com/kubeflow/spark-operator",
       "compatibility_matrix_url": "https://github.com/kubeflow/spark-operator#readme",
-      "changelog_location": "https://github.com/kubeflow/spark-operator/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubeflow/spark-operator/releases"
     },
     {
       "name": "KubeRay",
       "project_url": "https://ray-project.github.io/kuberay/",
       "repository": "https://github.com/ray-project/kuberay",
       "compatibility_matrix_url": "https://ray-project.github.io/kuberay/deploy/installation/",
-      "changelog_location": "https://github.com/ray-project/kuberay/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/ray-project/kuberay/releases"
     },
     {
       "name": "Kubeflow Pipelines",
       "project_url": "https://www.kubeflow.org/docs/components/pipelines/",
       "repository": "https://github.com/kubeflow/pipelines",
       "compatibility_matrix_url": "https://www.kubeflow.org/docs/components/pipelines/installation/overview/",
-      "changelog_location": "https://github.com/kubeflow/pipelines/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubeflow/pipelines/releases"
     },
     {
       "name": "KServe",
       "project_url": "https://kserve.github.io/website/",
       "repository": "https://github.com/kserve/kserve",
       "compatibility_matrix_url": "https://kserve.github.io/website/latest/admin/serverless/serverless/",
-      "changelog_location": "https://github.com/kserve/kserve/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kserve/kserve/releases"
     },
     {
       "name": "Seldon Core",
       "project_url": "https://www.seldon.io/solutions/open-source-projects/core",
       "repository": "https://github.com/SeldonIO/seldon-core",
       "compatibility_matrix_url": "https://docs.seldon.io/projects/seldon-core/en/latest/install/index.html",
-      "changelog_location": "https://github.com/SeldonIO/seldon-core/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/SeldonIO/seldon-core/releases"
     },
     {
       "name": "KubeVela",
       "project_url": "https://kubevela.io/",
       "repository": "https://github.com/kubevela/kubevela",
       "compatibility_matrix_url": "https://kubevela.io/docs/install",
-      "changelog_location": "https://github.com/kubevela/kubevela/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubevela/kubevela/releases"
     },
     {
       "name": "Keda HTTP Add-on",
       "project_url": "https://github.com/kedacore/http-add-on",
       "repository": "https://github.com/kedacore/http-add-on",
       "compatibility_matrix_url": "https://github.com/kedacore/http-add-on#readme",
-      "changelog_location": "https://github.com/kedacore/http-add-on/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kedacore/http-add-on/releases"
     },
     {
       "name": "Cluster Autoscaler",
       "project_url": "https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler",
       "repository": "https://github.com/kubernetes/autoscaler",
       "compatibility_matrix_url": "https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler#releases",
-      "changelog_location": "https://github.com/kubernetes/autoscaler/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubernetes/autoscaler/releases"
     },
     {
       "name": "Vertical Pod Autoscaler (VPA)",
       "project_url": "https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler",
       "repository": "https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler",
       "compatibility_matrix_url": "https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler#installation",
-      "changelog_location": "https://github.com/kubernetes/autoscaler/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubernetes/autoscaler/releases"
     },
     {
       "name": "Velero UI (CloudCasa)",
       "project_url": "https://www.catalogicsoftware.com/cloudcasa",
       "repository": "https://github.com/catalogicsoftware/cloudcasa-uno",
       "compatibility_matrix_url": "https://docs.cloudcasa.io/help/getting-started/",
-      "changelog_location": "https://docs.cloudcasa.io/help/release-notes/",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://docs.cloudcasa.io/help/release-notes/"
     },
     {
       "name": "Kasten K10",
       "project_url": "https://www.kasten.io/product/",
       "repository": "https://github.com/kastenhq/external-tools",
       "compatibility_matrix_url": "https://docs.kasten.io/latest/operating/support.html",
-      "changelog_location": "https://docs.kasten.io/latest/releasenotes.html",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://docs.kasten.io/latest/releasenotes.html"
     },
     {
       "name": "Trilio for Kubernetes (TrilioVault)",
       "project_url": "https://trilio.io/products/triliovault-kubernetes/",
       "repository": "https://github.com/trilioData/tvk-plugins",
       "compatibility_matrix_url": "https://docs.trilio.io/kubernetes/appendix/compatibility-matrix",
-      "changelog_location": "https://docs.trilio.io/kubernetes/overview/release-notes",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://docs.trilio.io/kubernetes/overview/release-notes"
     },
     {
       "name": "Buildpacks (pack)",
       "project_url": "https://buildpacks.io/",
       "repository": "https://github.com/buildpacks/pack",
       "compatibility_matrix_url": "https://buildpacks.io/docs/tools/pack/",
-      "changelog_location": "https://github.com/buildpacks/pack/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/buildpacks/pack/releases"
     },
     {
       "name": "Buildah",
       "project_url": "https://buildah.io/",
       "repository": "https://github.com/containers/buildah",
       "compatibility_matrix_url": "https://github.com/containers/buildah/blob/main/install.md",
-      "changelog_location": "https://github.com/containers/buildah/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/containers/buildah/releases"
     },
     {
       "name": "Kaniko",
       "project_url": "https://github.com/GoogleContainerTools/kaniko",
       "repository": "https://github.com/GoogleContainerTools/kaniko",
       "compatibility_matrix_url": "https://github.com/GoogleContainerTools/kaniko#running-kaniko",
-      "changelog_location": "https://github.com/GoogleContainerTools/kaniko/releases",
-      "upgrade_path_type": "Container-image"
+      "changelog_location": "https://github.com/GoogleContainerTools/kaniko/releases"
     },
     {
       "name": "ko",
       "project_url": "https://ko.build/",
       "repository": "https://github.com/ko-build/ko",
       "compatibility_matrix_url": "https://ko.build/install/",
-      "changelog_location": "https://github.com/ko-build/ko/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/ko-build/ko/releases"
     },
     {
       "name": "Devtron",
       "project_url": "https://devtron.ai/",
       "repository": "https://github.com/devtron-labs/devtron",
       "compatibility_matrix_url": "https://docs.devtron.ai/install",
-      "changelog_location": "https://github.com/devtron-labs/devtron/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/devtron-labs/devtron/releases"
     },
     {
       "name": "Keptn",
       "project_url": "https://keptn.sh/",
       "repository": "https://github.com/keptn/lifecycle-toolkit",
       "compatibility_matrix_url": "https://v1.keptn.sh/docs/0.10.x/operate/k8s_support/",
-      "changelog_location": "https://github.com/keptn/lifecycle-toolkit/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/keptn/lifecycle-toolkit/releases"
     },
     {
       "name": "Werf",
       "project_url": "https://werf.io/",
       "repository": "https://github.com/werf/werf",
       "compatibility_matrix_url": "https://werf.io/installation.html",
-      "changelog_location": "https://github.com/werf/werf/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/werf/werf/releases"
     },
     {
       "name": "GitLab Runner (Kubernetes Executor)",
       "project_url": "https://docs.gitlab.com/runner/executors/kubernetes/",
       "repository": "https://gitlab.com/gitlab-org/gitlab-runner",
       "compatibility_matrix_url": "https://docs.gitlab.com/runner/install/kubernetes.html",
-      "changelog_location": "https://gitlab.com/gitlab-org/gitlab-runner/-/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://gitlab.com/gitlab-org/gitlab-runner/-/releases"
     },
     {
       "name": "Jenkins X",
       "project_url": "https://jenkins-x.io/",
       "repository": "https://github.com/jenkins-x/jx",
       "compatibility_matrix_url": "https://jenkins-x.io/v3/admin/guides/k8s-upgrades/",
-      "changelog_location": "https://github.com/jenkins-x/jx/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/jenkins-x/jx/releases"
     },
     {
       "name": "Woodpecker CI",
       "project_url": "https://woodpecker-ci.org/",
       "repository": "https://github.com/woodpecker-ci/woodpecker",
       "compatibility_matrix_url": "https://woodpecker-ci.org/docs/administration/kubernetes",
-      "changelog_location": "https://github.com/woodpecker-ci/woodpecker/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/woodpecker-ci/woodpecker/releases"
     },
     {
       "name": "Prow",
       "project_url": "https://docs.prow.k8s.io/",
       "repository": "https://github.com/kubernetes-sigs/prow",
       "compatibility_matrix_url": "https://docs.prow.k8s.io/docs/getting-started-deploy/",
-      "changelog_location": "https://github.com/kubernetes-sigs/prow/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubernetes-sigs/prow/releases"
     },
     {
       "name": "Buildkit",
       "project_url": "https://github.com/moby/buildkit",
       "repository": "https://github.com/moby/buildkit",
       "compatibility_matrix_url": "https://github.com/moby/buildkit#readme",
-      "changelog_location": "https://github.com/moby/buildkit/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/moby/buildkit/releases"
     },
     {
       "name": "Buildpacks (pack CLI)",
       "project_url": "https://buildpacks.io/",
       "repository": "https://github.com/buildpacks/pack",
       "compatibility_matrix_url": "https://buildpacks.io/docs/install-pack/",
-      "changelog_location": "https://github.com/buildpacks/pack/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/buildpacks/pack/releases"
     },
     {
       "name": "Shipwright",
       "project_url": "https://shipwright.io/",
       "repository": "https://github.com/shipwright-io/build",
       "compatibility_matrix_url": "https://github.com/shipwright-io/build#readme",
-      "changelog_location": "https://github.com/shipwright-io/build/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/shipwright-io/build/releases"
     },
     {
       "name": "PipeCD",
       "project_url": "https://pipecd.dev/",
       "repository": "https://github.com/pipe-cd/pipecd",
       "compatibility_matrix_url": "https://pipecd.dev/docs/installation/",
-      "changelog_location": "https://github.com/pipe-cd/pipecd/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/pipe-cd/pipecd/releases"
     },
     {
       "name": "Spinnaker",
       "project_url": "https://spinnaker.io/",
       "repository": "https://github.com/spinnaker/spinnaker",
       "compatibility_matrix_url": "https://docs.armory.io/continuous-deployment/feature-status/continuous-deployment-matrix/",
-      "changelog_location": "https://spinnaker.io/changelogs/",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://spinnaker.io/changelogs/"
     },
     {
       "name": "Renovate",
       "project_url": "https://docs.renovatebot.com/",
       "repository": "https://github.com/renovatebot/renovate",
       "compatibility_matrix_url": "https://docs.renovatebot.com/getting-started/installing-onboarding/",
-      "changelog_location": "https://github.com/renovatebot/renovate/releases",
-      "upgrade_path_type": "Container-image"
+      "changelog_location": "https://github.com/renovatebot/renovate/releases"
     },
     {
       "name": "Argo Events",
       "project_url": "https://argoproj.github.io/argo-events/",
       "repository": "https://github.com/argoproj/argo-events",
       "compatibility_matrix_url": "https://argoproj.github.io/argo-events/installation/",
-      "changelog_location": "https://github.com/argoproj/argo-events/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/argoproj/argo-events/releases"
     },
     {
       "name": "Argo CD Autopilot",
       "project_url": "https://argocd-autopilot.readthedocs.io/",
       "repository": "https://github.com/argoproj-labs/argocd-autopilot",
       "compatibility_matrix_url": "https://argocd-autopilot.readthedocs.io/en/stable/Getting-Started/",
-      "changelog_location": "https://github.com/argoproj-labs/argocd-autopilot/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/argoproj-labs/argocd-autopilot/releases"
     },
     {
       "name": "Flux Notification Controller",
       "project_url": "https://fluxcd.io/flux/components/notification/",
       "repository": "https://github.com/fluxcd/notification-controller",
       "compatibility_matrix_url": "https://fluxcd.io/flux/installation/",
-      "changelog_location": "https://github.com/fluxcd/notification-controller/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/fluxcd/notification-controller/releases"
     },
     {
       "name": "Argo CD Image Updater",
       "project_url": "https://argocd-image-updater.readthedocs.io/",
       "repository": "https://github.com/argoproj-labs/argocd-image-updater",
       "compatibility_matrix_url": "https://argocd-image-updater.readthedocs.io/en/stable/install/installation/",
-      "changelog_location": "https://github.com/argoproj-labs/argocd-image-updater/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/argoproj-labs/argocd-image-updater/releases"
     },
     {
       "name": "Argo Image Updater",
       "project_url": "https://argocd-image-updater.readthedocs.io/",
       "repository": "https://github.com/argoproj-labs/argocd-image-updater",
       "compatibility_matrix_url": "https://argocd-image-updater.readthedocs.io/en/stable/install/installation/",
-      "changelog_location": "https://github.com/argoproj-labs/argocd-image-updater/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/argoproj-labs/argocd-image-updater/releases"
     },
     {
       "name": "Flux Image Automation",
       "project_url": "https://fluxcd.io/flux/components/image/",
       "repository": "https://github.com/fluxcd/image-reflector-controller",
       "compatibility_matrix_url": "https://fluxcd.io/flux/installation/",
-      "changelog_location": "https://github.com/fluxcd/image-reflector-controller/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/fluxcd/image-reflector-controller/releases"
     },
     {
       "name": "Tekton Pipelines",
       "project_url": "https://tekton.dev/",
       "repository": "https://github.com/tektoncd/pipeline",
       "compatibility_matrix_url": "https://github.com/tektoncd/pipeline#want-to-start-using-pipelines",
-      "changelog_location": "https://github.com/tektoncd/pipeline/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/tektoncd/pipeline/releases"
     },
     {
       "name": "Dagger",
       "project_url": "https://dagger.io/",
       "repository": "https://github.com/dagger/dagger",
       "compatibility_matrix_url": "https://docs.dagger.io/install",
-      "changelog_location": "https://github.com/dagger/dagger/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/dagger/dagger/releases"
     },
     {
       "name": "Argo Rollouts",
       "project_url": "https://argo-rollouts.readthedocs.io/",
       "repository": "https://github.com/argoproj/argo-rollouts",
       "compatibility_matrix_url": "https://argo-rollouts.readthedocs.io/en/stable/installation/",
-      "changelog_location": "https://github.com/argoproj/argo-rollouts/blob/master/CHANGELOG.md",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/argoproj/argo-rollouts/blob/master/CHANGELOG.md"
     },
     {
       "name": "Flagger",
       "project_url": "https://flagger.app/",
       "repository": "https://github.com/fluxcd/flagger",
       "compatibility_matrix_url": "https://docs.flagger.app/install/flagger-install-on-kubernetes",
-      "changelog_location": "https://github.com/fluxcd/flagger/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/fluxcd/flagger/releases"
     },
     {
       "name": "Argo Workflows",
       "project_url": "https://argo-workflows.readthedocs.io/",
       "repository": "https://github.com/argoproj/argo-workflows",
       "compatibility_matrix_url": "https://argo-workflows.readthedocs.io/en/stable/releases/",
-      "changelog_location": "https://github.com/argoproj/argo-workflows/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/argoproj/argo-workflows/releases"
     },
     {
       "name": "Kube-monkey",
       "project_url": "https://github.com/asobti/kube-monkey",
       "repository": "https://github.com/asobti/kube-monkey",
       "compatibility_matrix_url": "https://github.com/asobti/kube-monkey#deployment",
-      "changelog_location": "https://github.com/asobti/kube-monkey/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/asobti/kube-monkey/releases"
     },
     {
       "name": "AWS VPC CNI",
       "project_url": "https://github.com/aws/amazon-vpc-cni-k8s",
       "repository": "https://github.com/aws/amazon-vpc-cni-k8s",
       "compatibility_matrix_url": "https://github.com/aws/amazon-vpc-cni-k8s/blob/master/README.md#compatibility",
-      "changelog_location": "https://github.com/aws/amazon-vpc-cni-k8s/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/aws/amazon-vpc-cni-k8s/releases"
     },
     {
       "name": "Azure CNI",
       "project_url": "https://learn.microsoft.com/en-us/azure/aks/configure-azure-cni",
       "repository": "https://github.com/Azure/azure-container-networking",
       "compatibility_matrix_url": "https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions",
-      "changelog_location": "https://github.com/Azure/azure-container-networking/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/Azure/azure-container-networking/releases"
     },
     {
       "name": "GKE Dataplane V2 (Google Cloud CNI)",
       "project_url": "https://cloud.google.com/kubernetes-engine/docs/concepts/dataplane-v2",
       "repository": null,
       "compatibility_matrix_url": "https://cloud.google.com/kubernetes-engine/docs/concepts/dataplane-v2#requirements",
-      "changelog_location": "https://cloud.google.com/kubernetes-engine/docs/release-notes",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://cloud.google.com/kubernetes-engine/docs/release-notes"
     },
     {
       "name": "Weave Net",
       "project_url": "https://www.weave.works/oss/net/",
       "repository": "https://github.com/weaveworks/weave",
       "compatibility_matrix_url": "https://github.com/weaveworks/weave/blob/master/docs/kubernetes.md",
-      "changelog_location": "https://github.com/weaveworks/weave/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/weaveworks/weave/releases"
     },
     {
       "name": "Akri",
       "project_url": "https://docs.akri.sh/",
       "repository": "https://github.com/project-akri/akri",
       "compatibility_matrix_url": "https://docs.akri.sh/user-guide/cluster-setup",
-      "changelog_location": "https://github.com/project-akri/akri/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/project-akri/akri/releases"
     },
     {
       "name": "AWS EBS CSI Driver",
       "project_url": "https://github.com/kubernetes-sigs/aws-ebs-csi-driver",
       "repository": "https://github.com/kubernetes-sigs/aws-ebs-csi-driver",
       "compatibility_matrix_url": "https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/README.md#kubernetes-version-compatibility-matrix",
-      "changelog_location": "https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases"
     },
     {
       "name": "Azure Disk CSI Driver",
       "project_url": "https://github.com/kubernetes-sigs/azuredisk-csi-driver",
       "repository": "https://github.com/kubernetes-sigs/azuredisk-csi-driver",
       "compatibility_matrix_url": "https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/master/README.md#container-images--csi-compatibility",
-      "changelog_location": "https://github.com/kubernetes-sigs/azuredisk-csi-driver/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubernetes-sigs/azuredisk-csi-driver/releases"
     },
     {
       "name": "GCP Persistent Disk CSI Driver",
       "project_url": "https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver",
       "repository": "https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver",
       "compatibility_matrix_url": "https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/master/README.md#kubernetes-compatibility",
-      "changelog_location": "https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/releases"
     },
     {
       "name": "vSphere CSI Driver",
       "project_url": "https://github.com/kubernetes-sigs/vsphere-csi-driver",
       "repository": "https://github.com/kubernetes-sigs/vsphere-csi-driver",
       "compatibility_matrix_url": "https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/index.html",
-      "changelog_location": "https://github.com/kubernetes-sigs/vsphere-csi-driver/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubernetes-sigs/vsphere-csi-driver/releases"
     },
     {
       "name": "AWS EFS CSI Driver",
       "project_url": "https://github.com/kubernetes-sigs/aws-efs-csi-driver",
       "repository": "https://github.com/kubernetes-sigs/aws-efs-csi-driver",
       "compatibility_matrix_url": "https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/docs/compatibility.md",
-      "changelog_location": "https://github.com/kubernetes-sigs/aws-efs-csi-driver/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubernetes-sigs/aws-efs-csi-driver/releases"
     },
     {
       "name": "Azure File CSI Driver",
       "project_url": "https://github.com/kubernetes-sigs/azurefile-csi-driver",
       "repository": "https://github.com/kubernetes-sigs/azurefile-csi-driver",
       "compatibility_matrix_url": "https://github.com/kubernetes-sigs/azurefile-csi-driver/blob/master/README.md#container-images--csi-compatibility",
-      "changelog_location": "https://github.com/kubernetes-sigs/azurefile-csi-driver/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubernetes-sigs/azurefile-csi-driver/releases"
     },
     {
       "name": "NFS Subdir External Provisioner",
       "project_url": "https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner",
       "repository": "https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner",
       "compatibility_matrix_url": "https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/blob/master/README.md",
-      "changelog_location": "https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/releases"
     },
     {
       "name": "TopoLVM",
       "project_url": "https://github.com/topolvm/topolvm",
       "repository": "https://github.com/topolvm/topolvm",
       "compatibility_matrix_url": "https://github.com/topolvm/topolvm/blob/main/README.md#supported-environments",
-      "changelog_location": "https://github.com/topolvm/topolvm/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/topolvm/topolvm/releases"
     },
     {
       "name": "Local Path Provisioner",
       "project_url": "https://github.com/rancher/local-path-provisioner",
       "repository": "https://github.com/rancher/local-path-provisioner",
       "compatibility_matrix_url": "https://github.com/rancher/local-path-provisioner/blob/master/README.md#requirement",
-      "changelog_location": "https://github.com/rancher/local-path-provisioner/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/rancher/local-path-provisioner/releases"
     },
     {
       "name": "democratic-csi",
       "project_url": "https://github.com/democratic-csi/democratic-csi",
       "repository": "https://github.com/democratic-csi/democratic-csi",
       "compatibility_matrix_url": "https://github.com/democratic-csi/democratic-csi#readme",
-      "changelog_location": "https://github.com/democratic-csi/democratic-csi/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/democratic-csi/democratic-csi/releases"
     },
     {
       "name": "SeaweedFS",
       "project_url": "https://github.com/seaweedfs/seaweedfs",
       "repository": "https://github.com/seaweedfs/seaweedfs",
       "compatibility_matrix_url": "https://github.com/seaweedfs/seaweedfs/wiki/Kubernetes",
-      "changelog_location": "https://github.com/seaweedfs/seaweedfs/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/seaweedfs/seaweedfs/releases"
     },
     {
       "name": "Snapshotting / Volume Snapshot Controller",
       "project_url": "https://github.com/kubernetes-csi/external-snapshotter",
       "repository": "https://github.com/kubernetes-csi/external-snapshotter",
       "compatibility_matrix_url": "https://github.com/kubernetes-csi/external-snapshotter#readme",
-      "changelog_location": "https://github.com/kubernetes-csi/external-snapshotter/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubernetes-csi/external-snapshotter/releases"
     },
     {
       "name": "Volume Snapshot Controller (external-snapshotter)",
       "project_url": "https://github.com/kubernetes-csi/external-snapshotter",
       "repository": "https://github.com/kubernetes-csi/external-snapshotter",
       "compatibility_matrix_url": "https://github.com/kubernetes-csi/external-snapshotter#readme",
-      "changelog_location": "https://github.com/kubernetes-csi/external-snapshotter/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubernetes-csi/external-snapshotter/releases"
     },
     {
       "name": "AWS Cloud Controller Manager",
       "project_url": "https://github.com/kubernetes/cloud-provider-aws",
       "repository": "https://github.com/kubernetes/cloud-provider-aws",
       "compatibility_matrix_url": "https://github.com/kubernetes/cloud-provider-aws#readme",
-      "changelog_location": "https://github.com/kubernetes/cloud-provider-aws/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubernetes/cloud-provider-aws/releases"
     },
     {
       "name": "Cluster API Provider AWS (CAPA)",
       "project_url": "https://cluster-api-aws.sigs.k8s.io/",
       "repository": "https://github.com/kubernetes-sigs/cluster-api-provider-aws",
       "compatibility_matrix_url": "https://cluster-api-aws.sigs.k8s.io/getting-started",
-      "changelog_location": "https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases"
     },
     {
       "name": "AWS Pod Identity Webhook",
       "project_url": "https://github.com/aws/amazon-eks-pod-identity-webhook",
       "repository": "https://github.com/aws/amazon-eks-pod-identity-webhook",
       "compatibility_matrix_url": "https://github.com/aws/amazon-eks-pod-identity-webhook#readme",
-      "changelog_location": "https://github.com/aws/amazon-eks-pod-identity-webhook/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/aws/amazon-eks-pod-identity-webhook/releases"
     },
     {
       "name": "AWS Node Termination Handler",
       "project_url": "https://github.com/aws/aws-node-termination-handler",
       "repository": "https://github.com/aws/aws-node-termination-handler",
       "compatibility_matrix_url": "https://github.com/aws/aws-node-termination-handler#readme",
-      "changelog_location": "https://github.com/aws/aws-node-termination-handler/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/aws/aws-node-termination-handler/releases"
     },
     {
       "name": "AWS Controllers for Kubernetes (ACK)",
       "project_url": "https://aws-controllers-k8s.github.io/community/",
       "repository": "https://github.com/aws-controllers-k8s/community",
       "compatibility_matrix_url": "https://aws-controllers-k8s.github.io/community/docs/user-docs/install/",
-      "changelog_location": "https://github.com/aws-controllers-k8s/community/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/aws-controllers-k8s/community/releases"
     },
     {
       "name": "AWS FSx CSI Driver",
       "project_url": "https://github.com/kubernetes-sigs/aws-fsx-csi-driver",
       "repository": "https://github.com/kubernetes-sigs/aws-fsx-csi-driver",
       "compatibility_matrix_url": "https://github.com/kubernetes-sigs/aws-fsx-csi-driver#readme",
-      "changelog_location": "https://github.com/kubernetes-sigs/aws-fsx-csi-driver/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubernetes-sigs/aws-fsx-csi-driver/releases"
     },
     {
       "name": "Azure Cloud Controller Manager",
       "project_url": "https://github.com/kubernetes-sigs/cloud-provider-azure",
       "repository": "https://github.com/kubernetes-sigs/cloud-provider-azure",
       "compatibility_matrix_url": "https://github.com/kubernetes-sigs/cloud-provider-azure#readme",
-      "changelog_location": "https://github.com/kubernetes-sigs/cloud-provider-azure/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubernetes-sigs/cloud-provider-azure/releases"
     },
     {
       "name": "Cluster API Provider Azure (CAPZ)",
       "project_url": "https://capz.sigs.k8s.io/",
       "repository": "https://github.com/kubernetes-sigs/cluster-api-provider-azure",
       "compatibility_matrix_url": "https://capz.sigs.k8s.io/introduction",
-      "changelog_location": "https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases"
     },
     {
       "name": "Azure Workload Identity",
       "project_url": "https://azure.github.io/azure-workload-identity/",
       "repository": "https://github.com/Azure/azure-workload-identity",
       "compatibility_matrix_url": "https://azure.github.io/azure-workload-identity/docs/installation.html",
-      "changelog_location": "https://github.com/Azure/azure-workload-identity/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/Azure/azure-workload-identity/releases"
     },
     {
       "name": "Azure Service Operator (ASO)",
       "project_url": "https://azure.github.io/azure-service-operator/",
       "repository": "https://github.com/Azure/azure-service-operator",
       "compatibility_matrix_url": "https://azure.github.io/azure-service-operator/#installation",
-      "changelog_location": "https://github.com/Azure/azure-service-operator/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/Azure/azure-service-operator/releases"
     },
     {
       "name": "Azure Blob CSI Driver",
       "project_url": "https://github.com/kubernetes-sigs/blob-csi-driver",
       "repository": "https://github.com/kubernetes-sigs/blob-csi-driver",
       "compatibility_matrix_url": "https://github.com/kubernetes-sigs/blob-csi-driver#readme",
-      "changelog_location": "https://github.com/kubernetes-sigs/blob-csi-driver/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubernetes-sigs/blob-csi-driver/releases"
     },
     {
       "name": "DigitalOcean Cloud Controller Manager",
       "project_url": "https://github.com/digitalocean/digitalocean-cloud-controller-manager",
       "repository": "https://github.com/digitalocean/digitalocean-cloud-controller-manager",
       "compatibility_matrix_url": "https://github.com/digitalocean/digitalocean-cloud-controller-manager#readme",
-      "changelog_location": "https://github.com/digitalocean/digitalocean-cloud-controller-manager/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/digitalocean/digitalocean-cloud-controller-manager/releases"
     },
     {
       "name": "DigitalOcean CSI Driver",
       "project_url": "https://github.com/digitalocean/csi-digitalocean",
       "repository": "https://github.com/digitalocean/csi-digitalocean",
       "compatibility_matrix_url": "https://github.com/digitalocean/csi-digitalocean#readme",
-      "changelog_location": "https://github.com/digitalocean/csi-digitalocean/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/digitalocean/csi-digitalocean/releases"
     },
     {
       "name": "GCP Cloud Controller Manager",
       "project_url": "https://github.com/kubernetes/cloud-provider-gcp",
       "repository": "https://github.com/kubernetes/cloud-provider-gcp",
       "compatibility_matrix_url": "https://github.com/kubernetes/cloud-provider-gcp#readme",
-      "changelog_location": "https://github.com/kubernetes/cloud-provider-gcp/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubernetes/cloud-provider-gcp/releases"
     },
     {
       "name": "GCP Config Connector",
       "project_url": "https://cloud.google.com/config-connector/docs/overview",
       "repository": "https://github.com/GoogleCloudPlatform/k8s-config-connector",
       "compatibility_matrix_url": "https://cloud.google.com/config-connector/docs/how-to/install-upgrade-uninstall",
-      "changelog_location": "https://github.com/GoogleCloudPlatform/k8s-config-connector/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/GoogleCloudPlatform/k8s-config-connector/releases"
     },
     {
       "name": "GCP Secrets Store CSI Driver Provider",
       "project_url": "https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp",
       "repository": "https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp",
       "compatibility_matrix_url": "https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp#readme",
-      "changelog_location": "https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/releases"
     },
     {
       "name": "Hetzner Cloud Controller Manager",
       "project_url": "https://github.com/hetznercloud/hcloud-cloud-controller-manager",
       "repository": "https://github.com/hetznercloud/hcloud-cloud-controller-manager",
       "compatibility_matrix_url": "https://github.com/hetznercloud/hcloud-cloud-controller-manager#readme",
-      "changelog_location": "https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases"
     },
     {
       "name": "Hetzner CSI Driver",
       "project_url": "https://github.com/hetznercloud/csi-driver",
       "repository": "https://github.com/hetznercloud/csi-driver",
       "compatibility_matrix_url": "https://github.com/hetznercloud/csi-driver#readme",
-      "changelog_location": "https://github.com/hetznercloud/csi-driver/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/hetznercloud/csi-driver/releases"
     },
     {
       "name": "Linode CSI Driver",
       "project_url": "https://github.com/linode/linode-blockstorage-csi-driver",
       "repository": "https://github.com/linode/linode-blockstorage-csi-driver",
       "compatibility_matrix_url": "https://github.com/linode/linode-blockstorage-csi-driver#readme",
-      "changelog_location": "https://github.com/linode/linode-blockstorage-csi-driver/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/linode/linode-blockstorage-csi-driver/releases"
     },
     {
       "name": "OCI Cloud Controller Manager",
       "project_url": "https://github.com/oracle/oci-cloud-controller-manager",
       "repository": "https://github.com/oracle/oci-cloud-controller-manager",
       "compatibility_matrix_url": "https://github.com/oracle/oci-cloud-controller-manager#readme",
-      "changelog_location": "https://github.com/oracle/oci-cloud-controller-manager/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/oracle/oci-cloud-controller-manager/releases"
     },
     {
       "name": "OCI Native Ingress Controller",
       "project_url": "https://github.com/oracle/oci-native-ingress-controller",
       "repository": "https://github.com/oracle/oci-native-ingress-controller",
       "compatibility_matrix_url": "https://github.com/oracle/oci-native-ingress-controller#readme",
-      "changelog_location": "https://github.com/oracle/oci-native-ingress-controller/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/oracle/oci-native-ingress-controller/releases"
     },
     {
       "name": "kube-no-trouble (kubent)",
       "project_url": "https://github.com/doitintl/kube-no-trouble",
       "repository": "https://github.com/doitintl/kube-no-trouble",
       "compatibility_matrix_url": "https://github.com/doitintl/kube-no-trouble#installation",
-      "changelog_location": "https://github.com/doitintl/kube-no-trouble/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/doitintl/kube-no-trouble/releases"
     },
     {
       "name": "Gardener",
       "project_url": "https://gardener.cloud/",
       "repository": "https://github.com/gardener/gardener",
       "compatibility_matrix_url": "https://gardener.cloud/docs/gardener/version_skew_policy/",
-      "changelog_location": "https://github.com/gardener/gardener/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/gardener/gardener/releases"
     },
     {
       "name": "Cluster API (CAPI)",
       "project_url": "https://cluster-api.sigs.k8s.io/",
       "repository": "https://github.com/kubernetes-sigs/cluster-api",
       "compatibility_matrix_url": "https://cluster-api.sigs.k8s.io/reference/versions",
-      "changelog_location": "https://github.com/kubernetes-sigs/cluster-api/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/kubernetes-sigs/cluster-api/releases"
     },
     {
       "name": "Kubespray",
       "project_url": "https://kubespray.io/",
       "repository": "https://github.com/kubernetes-sigs/kubespray",
       "compatibility_matrix_url": "https://github.com/kubernetes-sigs/kubespray#supported-components",
-      "changelog_location": "https://github.com/kubernetes-sigs/kubespray/releases",
-      "upgrade_path_type": "Ansible-playbook"
+      "changelog_location": "https://github.com/kubernetes-sigs/kubespray/releases"
     },
     {
       "name": "Kamaji",
       "project_url": "https://kamaji.clastix.io/",
       "repository": "https://github.com/clastix/kamaji",
       "compatibility_matrix_url": "https://kamaji.clastix.io/getting-started/",
-      "changelog_location": "https://github.com/clastix/kamaji/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/clastix/kamaji/releases"
     },
     {
       "name": "Flatcar Container Linux",
       "project_url": "https://www.flatcar.org/",
       "repository": "https://github.com/flatcar/Flatcar",
       "compatibility_matrix_url": "https://www.flatcar.org/releases",
-      "changelog_location": "https://www.flatcar.org/releases",
-      "upgrade_path_type": "Auto-update"
+      "changelog_location": "https://www.flatcar.org/releases"
     },
     {
       "name": "Talos Linux",
       "project_url": "https://www.talos.dev/",
       "repository": "https://github.com/siderolabs/talos",
       "compatibility_matrix_url": "https://www.talos.dev/latest/introduction/support-matrix/",
-      "changelog_location": "https://github.com/siderolabs/talos/releases",
-      "upgrade_path_type": "API-driven"
+      "changelog_location": "https://github.com/siderolabs/talos/releases"
     },
     {
       "name": "Deckhouse",
       "project_url": "https://deckhouse.io/",
       "repository": "https://github.com/deckhouse/deckhouse",
       "compatibility_matrix_url": "https://deckhouse.io/documentation/latest/supported_versions.html",
-      "changelog_location": "https://github.com/deckhouse/deckhouse/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/deckhouse/deckhouse/releases"
     },
     {
       "name": "Sveltos",
       "project_url": "https://projectsveltos.github.io/sveltos/",
       "repository": "https://github.com/projectsveltos/sveltos-manager",
       "compatibility_matrix_url": "https://projectsveltos.github.io/sveltos/getting_started/install/install/",
-      "changelog_location": "https://github.com/projectsveltos/sveltos-manager/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/projectsveltos/sveltos-manager/releases"
     },
     {
       "name": "vCluster",
       "project_url": "https://www.vcluster.com/",
       "repository": "https://github.com/loft-sh/vcluster",
       "compatibility_matrix_url": "https://www.vcluster.com/docs/getting-started/setup",
-      "changelog_location": "https://github.com/loft-sh/vcluster/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/loft-sh/vcluster/releases"
     },
     {
       "name": "NVIDIA GPU Operator",
       "project_url": "https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html",
       "repository": "https://github.com/NVIDIA/gpu-operator",
       "compatibility_matrix_url": "https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/platform-support.html",
-      "changelog_location": "https://github.com/NVIDIA/gpu-operator/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/NVIDIA/gpu-operator/releases"
     },
     {
       "name": "KubeVirt",
       "project_url": "https://kubevirt.io/",
       "repository": "https://github.com/kubevirt/kubevirt",
       "compatibility_matrix_url": "https://github.com/kubevirt/sig-release/blob/main/releases/k8s-support-matrix.md",
-      "changelog_location": "https://github.com/kubevirt/kubevirt/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/kubevirt/kubevirt/releases"
     },
     {
       "name": "CAST AI",
       "project_url": "https://cast.ai/",
       "repository": "https://github.com/castai/cluster-controller",
       "compatibility_matrix_url": "https://docs.cast.ai/docs/prerequisites",
-      "changelog_location": "https://docs.cast.ai/changelog/",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://docs.cast.ai/changelog/"
     },
     {
       "name": "Spot Ocean",
       "project_url": "https://spot.io/product/ocean/",
       "repository": "https://github.com/spotinst/spotinst-sdk-go",
       "compatibility_matrix_url": "https://docs.spot.io/ocean/getting-started/",
-      "changelog_location": "https://docs.spot.io/release-notes/",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://docs.spot.io/release-notes/"
     },
     {
       "name": "Finout",
       "project_url": "https://www.finout.io/",
       "repository": "https://github.com/finout-io/finout-helm",
       "compatibility_matrix_url": "https://docs.finout.io/docs/kubernetes-agent",
-      "changelog_location": "https://github.com/finout-io/finout-helm/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/finout-io/finout-helm/releases"
     },
     {
       "name": "StormForge (Optimize Live)",
       "project_url": "https://www.stormforge.io/",
       "repository": "https://github.com/thestormforge/optimize-controller",
       "compatibility_matrix_url": "https://docs.stormforge.io/optimize-live/getting-started/install/",
-      "changelog_location": "https://github.com/thestormforge/optimize-controller/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/thestormforge/optimize-controller/releases"
     },
     {
       "name": "ExternalDNS",
       "project_url": "https://kubernetes-sigs.github.io/external-dns/",
       "repository": "https://github.com/kubernetes-sigs/external-dns",
       "compatibility_matrix_url": "https://github.com/kubernetes-sigs/external-dns#kubernetes-version-compatibility",
-      "changelog_location": "https://github.com/kubernetes-sigs/external-dns/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubernetes-sigs/external-dns/releases"
     },
     {
       "name": "NodeLocal DNSCache",
       "project_url": "https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/",
       "repository": "https://github.com/kubernetes/dns",
       "compatibility_matrix_url": "https://github.com/kubernetes/dns#version-compat",
-      "changelog_location": "https://github.com/kubernetes/dns/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubernetes/dns/releases"
     },
     {
       "name": "Dagster",
       "project_url": "https://dagster.io/",
       "repository": "https://github.com/dagster-io/dagster",
       "compatibility_matrix_url": "https://docs.dagster.io/deployment/guides/kubernetes/deploying-with-helm",
-      "changelog_location": "https://github.com/dagster-io/dagster/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/dagster-io/dagster/releases"
     },
     {
       "name": "Aerospike Kubernetes Operator",
       "project_url": "https://aerospike.com/docs/cloud/kubernetes/operator/",
       "repository": "https://github.com/aerospike/aerospike-kubernetes-operator",
       "compatibility_matrix_url": "https://aerospike.com/docs/cloud/kubernetes/operator/",
-      "changelog_location": "https://github.com/aerospike/aerospike-kubernetes-operator/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/aerospike/aerospike-kubernetes-operator/releases"
     },
     {
       "name": "ClickHouse Operator",
       "project_url": "https://github.com/Altinity/clickhouse-operator",
       "repository": "https://github.com/Altinity/clickhouse-operator",
       "compatibility_matrix_url": "https://github.com/Altinity/clickhouse-operator/blob/master/docs/quick_start.md",
-      "changelog_location": "https://github.com/Altinity/clickhouse-operator/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/Altinity/clickhouse-operator/releases"
     },
     {
       "name": "CloudNativePG",
       "project_url": "https://cloudnative-pg.io/",
       "repository": "https://github.com/cloudnative-pg/cloudnative-pg",
       "compatibility_matrix_url": "https://cloudnative-pg.io/docs/latest/supported_releases/",
-      "changelog_location": "https://github.com/cloudnative-pg/cloudnative-pg/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/cloudnative-pg/cloudnative-pg/releases"
     },
     {
       "name": "CockroachDB Operator",
       "project_url": "https://www.cockroachlabs.com/docs/stable/operate-cockroachdb-kubernetes",
       "repository": "https://github.com/cockroachdb/cockroach-operator",
       "compatibility_matrix_url": "https://github.com/cockroachdb/cockroach-operator#readme",
-      "changelog_location": "https://github.com/cockroachdb/cockroach-operator/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/cockroachdb/cockroach-operator/releases"
     },
     {
       "name": "Crunchy PGO (Postgres Operator)",
       "project_url": "https://access.crunchydata.com/documentation/postgres-operator/latest/",
       "repository": "https://github.com/CrunchyData/postgres-operator",
       "compatibility_matrix_url": "https://access.crunchydata.com/documentation/postgres-operator/latest/installation/prerequisites/",
-      "changelog_location": "https://github.com/CrunchyData/postgres-operator/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/CrunchyData/postgres-operator/releases"
     },
     {
       "name": "K8ssandra (Cassandra Operator)",
       "project_url": "https://k8ssandra.io/",
       "repository": "https://github.com/k8ssandra/k8ssandra-operator",
       "compatibility_matrix_url": "https://docs.k8ssandra.io/install/",
-      "changelog_location": "https://github.com/k8ssandra/k8ssandra-operator/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/k8ssandra/k8ssandra-operator/releases"
     },
     {
       "name": "MongoDB Community Kubernetes Operator",
       "project_url": "https://github.com/mongodb/mongodb-kubernetes-operator",
       "repository": "https://github.com/mongodb/mongodb-kubernetes-operator",
       "compatibility_matrix_url": "https://github.com/mongodb/mongodb-kubernetes-operator#readme",
-      "changelog_location": "https://github.com/mongodb/mongodb-kubernetes-operator/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/mongodb/mongodb-kubernetes-operator/releases"
     },
     {
       "name": "MySQL Operator for Kubernetes",
       "project_url": "https://dev.mysql.com/doc/mysql-operator/en/",
       "repository": "https://github.com/mysql/mysql-operator",
       "compatibility_matrix_url": "https://dev.mysql.com/doc/mysql-operator/en/mysql-operator-introduction.html",
-      "changelog_location": "https://github.com/mysql/mysql-operator/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/mysql/mysql-operator/releases"
     },
     {
       "name": "Percona Operator for MongoDB",
       "project_url": "https://www.percona.com/mongodb/software/percona-operator-for-mongodb",
       "repository": "https://github.com/percona/percona-server-mongodb-operator",
       "compatibility_matrix_url": "https://docs.percona.com/percona-operator-for-mongodb/System-Requirements.html",
-      "changelog_location": "https://github.com/percona/percona-server-mongodb-operator/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/percona/percona-server-mongodb-operator/releases"
     },
     {
       "name": "Percona Operator for MongoDB (PSMDB)",
       "project_url": "https://www.percona.com/mongodb/software/percona-operator-for-mongodb",
       "repository": "https://github.com/percona/percona-server-mongodb-operator",
       "compatibility_matrix_url": "https://docs.percona.com/percona-operator-for-mongodb/System-Requirements.html",
-      "changelog_location": "https://github.com/percona/percona-server-mongodb-operator/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/percona/percona-server-mongodb-operator/releases"
     },
     {
       "name": "Percona Operator for MySQL",
       "project_url": "https://www.percona.com/mysql/software/percona-operator-for-mysql",
       "repository": "https://github.com/percona/percona-xtradb-cluster-operator",
       "compatibility_matrix_url": "https://docs.percona.com/percona-operator-for-mysql/pxc/System-Requirements.html",
-      "changelog_location": "https://github.com/percona/percona-xtradb-cluster-operator/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/percona/percona-xtradb-cluster-operator/releases"
     },
     {
       "name": "Percona Operator for MySQL (PXC)",
       "project_url": "https://www.percona.com/mysql/software/percona-operator-for-mysql",
       "repository": "https://github.com/percona/percona-xtradb-cluster-operator",
       "compatibility_matrix_url": "https://docs.percona.com/percona-operator-for-mysql/pxc/System-Requirements.html",
-      "changelog_location": "https://github.com/percona/percona-xtradb-cluster-operator/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/percona/percona-xtradb-cluster-operator/releases"
     },
     {
       "name": "Percona Operator for PostgreSQL",
       "project_url": "https://www.percona.com/postgresql/software/percona-operator-for-postgresql",
       "repository": "https://github.com/percona/percona-postgresql-operator",
       "compatibility_matrix_url": "https://docs.percona.com/percona-operator-for-postgresql/2.0/System-Requirements.html",
-      "changelog_location": "https://github.com/percona/percona-postgresql-operator/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/percona/percona-postgresql-operator/releases"
     },
     {
       "name": "Redis Operator (OpsTree)",
       "project_url": "https://ot-redis-operator.netlify.app/",
       "repository": "https://github.com/OT-CONTAINER-KIT/redis-operator",
       "compatibility_matrix_url": "https://ot-redis-operator.netlify.app/docs/installation/",
-      "changelog_location": "https://github.com/OT-CONTAINER-KIT/redis-operator/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/OT-CONTAINER-KIT/redis-operator/releases"
     },
     {
       "name": "ScyllaDB Operator",
       "project_url": "https://operator.docs.scylladb.com/",
       "repository": "https://github.com/scylladb/scylla-operator",
       "compatibility_matrix_url": "https://operator.docs.scylladb.com/stable/generic.html",
-      "changelog_location": "https://github.com/scylladb/scylla-operator/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/scylladb/scylla-operator/releases"
     },
     {
       "name": "SpotHero Redis Operator (redis-operator by Spotahome)",
       "project_url": "https://github.com/spotahome/redis-operator",
       "repository": "https://github.com/spotahome/redis-operator",
       "compatibility_matrix_url": "https://github.com/spotahome/redis-operator#readme",
-      "changelog_location": "https://github.com/spotahome/redis-operator/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/spotahome/redis-operator/releases"
     },
     {
       "name": "TiDB Operator",
       "project_url": "https://docs.pingcap.com/tidb-in-kubernetes/stable",
       "repository": "https://github.com/pingcap/tidb-operator",
       "compatibility_matrix_url": "https://docs.pingcap.com/tidb-in-kubernetes/stable/prerequisites",
-      "changelog_location": "https://github.com/pingcap/tidb-operator/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/pingcap/tidb-operator/releases"
     },
     {
       "name": "Zalando Postgres Operator",
       "project_url": "https://postgres-operator.readthedocs.io/",
       "repository": "https://github.com/zalando/postgres-operator",
       "compatibility_matrix_url": "https://github.com/zalando/postgres-operator#supported-postgres--kubernetes-versions",
-      "changelog_location": "https://github.com/zalando/postgres-operator/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/zalando/postgres-operator/releases"
     },
     {
       "name": "Vitess",
       "project_url": "https://vitess.io/",
       "repository": "https://github.com/vitessio/vitess",
       "compatibility_matrix_url": "https://vitess.io/docs/get-started/operator/",
-      "changelog_location": "https://github.com/vitessio/vitess/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/vitessio/vitess/releases"
     },
     {
       "name": "EMQX Operator",
       "project_url": "https://www.emqx.io/docs/en/latest/deploy/install-k8s.html",
       "repository": "https://github.com/emqx/emqx-operator",
       "compatibility_matrix_url": "https://github.com/emqx/emqx-operator#readme",
-      "changelog_location": "https://github.com/emqx/emqx-operator/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/emqx/emqx-operator/releases"
     },
     {
       "name": "NATS",
       "project_url": "https://nats.io/",
       "repository": "https://github.com/nats-io/nats-server",
       "compatibility_matrix_url": "https://docs.nats.io/running-a-nats-service/nats-kubernetes",
-      "changelog_location": "https://github.com/nats-io/nats-server/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/nats-io/nats-server/releases"
     },
     {
       "name": "RabbitMQ Cluster Operator",
       "project_url": "https://www.rabbitmq.com/kubernetes/operator/operator-overview",
       "repository": "https://github.com/rabbitmq/cluster-operator",
       "compatibility_matrix_url": "https://www.rabbitmq.com/kubernetes/operator/operator-overview#prerequisites",
-      "changelog_location": "https://github.com/rabbitmq/cluster-operator/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/rabbitmq/cluster-operator/releases"
     },
     {
       "name": "Pulsar (Apache Pulsar)",
       "project_url": "https://pulsar.apache.org/",
       "repository": "https://github.com/apache/pulsar",
       "compatibility_matrix_url": "https://pulsar.apache.org/docs/getting-started-helm/",
-      "changelog_location": "https://github.com/apache/pulsar/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/apache/pulsar/releases"
     },
     {
       "name": "Strimzi Kafka Operator",
       "project_url": "https://strimzi.io/",
       "repository": "https://github.com/strimzi/strimzi-kafka-operator",
       "compatibility_matrix_url": "https://strimzi.io/downloads/",
-      "changelog_location": "https://github.com/strimzi/strimzi-kafka-operator/blob/main/CHANGELOG.md",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/strimzi/strimzi-kafka-operator/blob/main/CHANGELOG.md"
     },
     {
       "name": "Apache Solr Operator",
       "project_url": "https://solr.apache.org/operator/",
       "repository": "https://github.com/apache/solr-operator",
       "compatibility_matrix_url": "https://solr.apache.org/operator/articles/explore.html",
-      "changelog_location": "https://github.com/apache/solr-operator/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/apache/solr-operator/releases"
     },
     {
       "name": "Elasticsearch Operator (ECK)",
       "project_url": "https://www.elastic.co/guide/en/cloud-on-k8s/current/index.html",
       "repository": "https://github.com/elastic/cloud-on-k8s",
       "compatibility_matrix_url": "https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s_supported-versions.html",
-      "changelog_location": "https://github.com/elastic/cloud-on-k8s/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/elastic/cloud-on-k8s/releases"
     },
     {
       "name": "Airflow (Apache Airflow on Kubernetes)",
       "project_url": "https://airflow.apache.org/",
       "repository": "https://github.com/apache/airflow",
       "compatibility_matrix_url": "https://airflow.apache.org/docs/helm-chart/stable/index.html",
-      "changelog_location": "https://github.com/apache/airflow/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/apache/airflow/releases"
     },
     {
       "name": "Coder",
       "project_url": "https://coder.com/",
       "repository": "https://github.com/coder/coder",
       "compatibility_matrix_url": "https://coder.com/docs/install/kubernetes",
-      "changelog_location": "https://github.com/coder/coder/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/coder/coder/releases"
     },
     {
       "name": "Eclipse Che",
       "project_url": "https://www.eclipse.org/che/",
       "repository": "https://github.com/eclipse/che",
       "compatibility_matrix_url": "https://eclipse.dev/che/docs/stable/administration-guide/installing-che/",
-      "changelog_location": "https://github.com/eclipse/che/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/eclipse/che/releases"
     },
     {
       "name": "Popeye",
       "project_url": "https://popeyecli.io/",
       "repository": "https://github.com/derailed/popeye",
       "compatibility_matrix_url": "https://github.com/derailed/popeye#installation",
-      "changelog_location": "https://github.com/derailed/popeye/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/derailed/popeye/releases"
     },
     {
       "name": "k9s",
       "project_url": "https://k9scli.io/",
       "repository": "https://github.com/derailed/k9s",
       "compatibility_matrix_url": "https://k9scli.io/topics/install/",
-      "changelog_location": "https://github.com/derailed/k9s/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/derailed/k9s/releases"
     },
     {
       "name": "kubectx / kubens",
       "project_url": "https://github.com/ahmetb/kubectx",
       "repository": "https://github.com/ahmetb/kubectx",
       "compatibility_matrix_url": "https://github.com/ahmetb/kubectx#installation",
-      "changelog_location": "https://github.com/ahmetb/kubectx/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/ahmetb/kubectx/releases"
     },
     {
       "name": "Okteto",
       "project_url": "https://www.okteto.com/",
       "repository": "https://github.com/okteto/okteto",
       "compatibility_matrix_url": "https://www.okteto.com/docs/get-started/install/",
-      "changelog_location": "https://github.com/okteto/okteto/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/okteto/okteto/releases"
     },
     {
       "name": "DevSpace",
       "project_url": "https://devspace.sh/",
       "repository": "https://github.com/devspace-sh/devspace",
       "compatibility_matrix_url": "https://devspace.sh/docs/getting-started/installation",
-      "changelog_location": "https://github.com/devspace-sh/devspace/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/devspace-sh/devspace/releases"
     },
     {
       "name": "Skaffold",
       "project_url": "https://skaffold.dev/",
       "repository": "https://github.com/GoogleContainerTools/skaffold",
       "compatibility_matrix_url": "https://skaffold.dev/docs/references/compatibility/",
-      "changelog_location": "https://github.com/GoogleContainerTools/skaffold/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/GoogleContainerTools/skaffold/releases"
     },
     {
       "name": "Tilt",
       "project_url": "https://tilt.dev/",
       "repository": "https://github.com/tilt-dev/tilt",
       "compatibility_matrix_url": "https://docs.tilt.dev/install.html",
-      "changelog_location": "https://github.com/tilt-dev/tilt/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/tilt-dev/tilt/releases"
     },
     {
       "name": "Gefyra",
       "project_url": "https://gefyra.dev/",
       "repository": "https://github.com/gefyrahq/gefyra",
       "compatibility_matrix_url": "https://gefyra.dev/getting-started/",
-      "changelog_location": "https://github.com/gefyrahq/gefyra/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/gefyrahq/gefyra/releases"
     },
     {
       "name": "Stern",
       "project_url": "https://github.com/stern/stern",
       "repository": "https://github.com/stern/stern",
       "compatibility_matrix_url": "https://github.com/stern/stern#installation",
-      "changelog_location": "https://github.com/stern/stern/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/stern/stern/releases"
     },
     {
       "name": "Krew",
       "project_url": "https://krew.sigs.k8s.io/",
       "repository": "https://github.com/kubernetes-sigs/krew",
       "compatibility_matrix_url": "https://krew.sigs.k8s.io/docs/user-guide/setup/install/",
-      "changelog_location": "https://github.com/kubernetes-sigs/krew/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/kubernetes-sigs/krew/releases"
     },
     {
       "name": "Bridge to Kubernetes",
       "project_url": "https://learn.microsoft.com/en-us/visualstudio/bridge/overview-bridge-to-kubernetes",
       "repository": "https://github.com/Azure/Bridge-To-Kubernetes",
       "compatibility_matrix_url": "https://learn.microsoft.com/en-us/visualstudio/bridge/overview-bridge-to-kubernetes#prerequisites",
-      "changelog_location": "https://github.com/Azure/Bridge-To-Kubernetes/releases",
-      "upgrade_path_type": "IDE-plugin"
+      "changelog_location": "https://github.com/Azure/Bridge-To-Kubernetes/releases"
     },
     {
       "name": "Telepresence",
       "project_url": "https://www.telepresence.io/",
       "repository": "https://github.com/telepresenceio/telepresence",
       "compatibility_matrix_url": "https://www.telepresence.io/docs/latest/install/",
-      "changelog_location": "https://github.com/telepresenceio/telepresence/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/telepresenceio/telepresence/releases"
     },
     {
       "name": "kubectl-neat",
       "project_url": "https://github.com/itaysk/kubectl-neat",
       "repository": "https://github.com/itaysk/kubectl-neat",
       "compatibility_matrix_url": "https://github.com/itaysk/kubectl-neat#installation",
-      "changelog_location": "https://github.com/itaysk/kubectl-neat/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/itaysk/kubectl-neat/releases"
     },
     {
       "name": "kubectl-tree",
       "project_url": "https://github.com/ahmetb/kubectl-tree",
       "repository": "https://github.com/ahmetb/kubectl-tree",
       "compatibility_matrix_url": "https://github.com/ahmetb/kubectl-tree#installation",
-      "changelog_location": "https://github.com/ahmetb/kubectl-tree/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/ahmetb/kubectl-tree/releases"
     },
     {
       "name": "Dragonfly",
       "project_url": "https://d7y.io/",
       "repository": "https://github.com/dragonflyoss/dragonfly",
       "compatibility_matrix_url": "https://d7y.io/docs/getting-started/quick-start/kubernetes/",
-      "changelog_location": "https://github.com/dragonflyoss/dragonfly/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/dragonflyoss/dragonfly/releases"
     },
     {
       "name": "Spegel",
       "project_url": "https://spegel.dev/",
       "repository": "https://github.com/spegel-org/spegel",
       "compatibility_matrix_url": "https://spegel.dev/docs/getting-started/",
-      "changelog_location": "https://github.com/spegel-org/spegel/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/spegel-org/spegel/releases"
     },
     {
       "name": "ingress-nginx",
       "project_url": "https://kubernetes.github.io/ingress-nginx/",
       "repository": "https://github.com/kubernetes/ingress-nginx",
       "compatibility_matrix_url": "https://github.com/kubernetes/ingress-nginx#supported-versions-table",
-      "changelog_location": "https://github.com/kubernetes/ingress-nginx/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubernetes/ingress-nginx/releases"
     },
     {
       "name": "AWS Load Balancer Controller",
       "project_url": "https://kubernetes-sigs.github.io/aws-load-balancer-controller/",
       "repository": "https://github.com/kubernetes-sigs/aws-load-balancer-controller",
       "compatibility_matrix_url": "https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/installation/",
-      "changelog_location": "https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases"
     },
     {
       "name": "Azure Application Gateway Ingress Controller (AGIC)",
       "project_url": "https://azure.github.io/application-gateway-kubernetes-ingress/",
       "repository": "https://github.com/Azure/application-gateway-kubernetes-ingress",
       "compatibility_matrix_url": "https://learn.microsoft.com/en-us/azure/application-gateway/ingress-controller-overview#supported-kubernetes-versions",
-      "changelog_location": "https://github.com/Azure/application-gateway-kubernetes-ingress/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/Azure/application-gateway-kubernetes-ingress/releases"
     },
     {
       "name": "NGINX Ingress Controller",
       "project_url": "https://kubernetes.github.io/ingress-nginx/",
       "repository": "https://github.com/kubernetes/ingress-nginx",
       "compatibility_matrix_url": "https://github.com/kubernetes/ingress-nginx#supported-versions-table",
-      "changelog_location": "https://github.com/kubernetes/ingress-nginx/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubernetes/ingress-nginx/releases"
     },
     {
       "name": "Kubernetes Dashboard",
       "project_url": "https://github.com/kubernetes/dashboard",
       "repository": "https://github.com/kubernetes/dashboard",
       "compatibility_matrix_url": "https://github.com/kubernetes/dashboard/releases",
-      "changelog_location": "https://github.com/kubernetes/dashboard/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubernetes/dashboard/releases"
     },
     {
       "name": "Prometheus Operator / kube-prometheus-stack",
       "project_url": "https://prometheus-operator.dev/",
       "repository": "https://github.com/prometheus-operator/prometheus-operator",
       "compatibility_matrix_url": "https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack",
-      "changelog_location": "https://github.com/prometheus-operator/prometheus-operator/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/prometheus-operator/prometheus-operator/releases"
     },
     {
       "name": "metrics-server",
       "project_url": "https://github.com/kubernetes-sigs/metrics-server",
       "repository": "https://github.com/kubernetes-sigs/metrics-server",
       "compatibility_matrix_url": "https://github.com/kubernetes-sigs/metrics-server#compatibility-matrix",
-      "changelog_location": "https://github.com/kubernetes-sigs/metrics-server/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubernetes-sigs/metrics-server/releases"
     },
     {
       "name": "Loft",
       "project_url": "https://loft.sh/",
       "repository": "https://github.com/loft-sh/loft",
       "compatibility_matrix_url": "https://loft.sh/docs/getting-started/install",
-      "changelog_location": "https://github.com/loft-sh/loft/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/loft-sh/loft/releases"
     },
     {
       "name": "Hierarchical Namespace Controller (HNC)",
       "project_url": "https://github.com/kubernetes-sigs/hierarchical-namespaces",
       "repository": "https://github.com/kubernetes-sigs/hierarchical-namespaces",
       "compatibility_matrix_url": "https://github.com/kubernetes-sigs/hierarchical-namespaces#readme",
-      "changelog_location": "https://github.com/kubernetes-sigs/hierarchical-namespaces/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubernetes-sigs/hierarchical-namespaces/releases"
     },
     {
       "name": "Kosmos",
       "project_url": "https://kosmos-io.github.io/website/",
       "repository": "https://github.com/kosmos-io/kosmos",
       "compatibility_matrix_url": "https://kosmos-io.github.io/website/docs/getting-started/introduction",
-      "changelog_location": "https://github.com/kosmos-io/kosmos/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kosmos-io/kosmos/releases"
     },
     {
       "name": "Liqo",
       "project_url": "https://docs.liqo.io/",
       "repository": "https://github.com/liqotech/liqo",
       "compatibility_matrix_url": "https://docs.liqo.io/installation/requirements.html",
-      "changelog_location": "https://github.com/liqotech/liqo/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/liqotech/liqo/releases"
     },
     {
       "name": "Admiralty",
       "project_url": "https://admiralty.io/",
       "repository": "https://github.com/admiraltyio/admiralty",
       "compatibility_matrix_url": "https://admiralty.io/docs/operator_guide/installation#prerequisites",
-      "changelog_location": "https://github.com/admiraltyio/admiralty/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/admiraltyio/admiralty/releases"
     },
     {
       "name": "Tigera Operator",
       "project_url": "https://docs.tigera.io/calico/latest/getting-started/kubernetes/",
       "repository": "https://github.com/tigera/operator",
       "compatibility_matrix_url": "https://docs.tigera.io/calico/latest/getting-started/kubernetes/requirements",
-      "changelog_location": "https://github.com/tigera/operator/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/tigera/operator/releases"
     },
     {
       "name": "Multus CNI",
       "project_url": "https://github.com/k8snetworkplumbingwg/multus-cni",
       "repository": "https://github.com/k8snetworkplumbingwg/multus-cni",
       "compatibility_matrix_url": "https://github.com/k8snetworkplumbingwg/multus-cni#readme",
-      "changelog_location": "https://github.com/k8snetworkplumbingwg/multus-cni/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/k8snetworkplumbingwg/multus-cni/releases"
     },
     {
       "name": "Whereabouts",
       "project_url": "https://github.com/k8snetworkplumbingwg/whereabouts",
       "repository": "https://github.com/k8snetworkplumbingwg/whereabouts",
       "compatibility_matrix_url": "https://github.com/k8snetworkplumbingwg/whereabouts#readme",
-      "changelog_location": "https://github.com/k8snetworkplumbingwg/whereabouts/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/k8snetworkplumbingwg/whereabouts/releases"
     },
     {
       "name": "Cilium ClusterMesh",
       "project_url": "https://docs.cilium.io/en/stable/network/clustermesh/",
       "repository": "https://github.com/cilium/cilium",
       "compatibility_matrix_url": "https://docs.cilium.io/en/stable/network/clustermesh/clustermesh/#prerequisites",
-      "changelog_location": "https://github.com/cilium/cilium/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/cilium/cilium/releases"
     },
     {
       "name": "Cilium Network Policy",
       "project_url": "https://docs.cilium.io/en/stable/security/policy/",
       "repository": "https://github.com/cilium/cilium",
       "compatibility_matrix_url": "https://docs.cilium.io/en/stable/network/kubernetes/policy/#kubernetes-policies",
-      "changelog_location": "https://github.com/cilium/cilium/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/cilium/cilium/releases"
     },
     {
       "name": "Kubernetes Network Policy (Calico)",
       "project_url": "https://docs.tigera.io/calico/latest/network-policy/",
       "repository": "https://github.com/projectcalico/calico",
       "compatibility_matrix_url": "https://docs.tigera.io/calico/latest/getting-started/kubernetes/requirements",
-      "changelog_location": "https://github.com/projectcalico/calico/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/projectcalico/calico/releases"
     },
     {
       "name": "Network Policy Editor (Cilium)",
       "project_url": "https://editor.networkpolicy.io/",
       "repository": "https://github.com/cilium/network-policy-editor",
       "compatibility_matrix_url": "https://editor.networkpolicy.io/",
-      "changelog_location": "https://github.com/cilium/network-policy-editor/releases",
-      "upgrade_path_type": "Web-tool"
+      "changelog_location": "https://github.com/cilium/network-policy-editor/releases"
     },
     {
       "name": "Istio Ambient Mesh",
       "project_url": "https://istio.io/latest/docs/ambient/",
       "repository": "https://github.com/istio/istio",
       "compatibility_matrix_url": "https://istio.io/latest/docs/ambient/install/",
-      "changelog_location": "https://github.com/istio/istio/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/istio/istio/releases"
     },
     {
       "name": "Istio Operator",
       "project_url": "https://istio.io/latest/docs/setup/install/operator/",
       "repository": "https://github.com/istio/istio",
       "compatibility_matrix_url": "https://istio.io/latest/docs/releases/supported-releases/",
-      "changelog_location": "https://github.com/istio/istio/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/istio/istio/releases"
     },
     {
       "name": "Calisti (formerly Backyards)",
       "project_url": "https://calisti.app/",
       "repository": "https://github.com/cisco-open/libnasp",
       "compatibility_matrix_url": "https://calisti.app/docs/",
-      "changelog_location": "https://calisti.app/docs/release-notes/",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://calisti.app/docs/release-notes/"
     },
     {
       "name": "Meshery",
       "project_url": "https://meshery.io/",
       "repository": "https://github.com/meshery/meshery",
       "compatibility_matrix_url": "https://docs.meshery.io/installation",
-      "changelog_location": "https://github.com/meshery/meshery/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/meshery/meshery/releases"
     },
     {
       "name": "3Scale APIcast",
       "project_url": "https://www.3scale.net/",
       "repository": "https://github.com/3scale/apicast",
       "compatibility_matrix_url": "https://access.redhat.com/articles/2798521",
-      "changelog_location": "https://github.com/3scale/apicast/blob/master/CHANGELOG.md",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/3scale/apicast/blob/master/CHANGELOG.md"
     },
     {
       "name": "Docker Swarm (SwarmKit)",
       "project_url": "https://docs.docker.com/engine/swarm/",
       "repository": "https://github.com/moby/swarmkit",
       "compatibility_matrix_url": "https://docs.docker.com/engine/swarm/",
-      "changelog_location": "https://github.com/moby/swarmkit/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/moby/swarmkit/releases"
     },
     {
       "name": "Elastic/Elasticsearch",
       "project_url": "https://www.elastic.co/",
       "repository": "https://github.com/elastic/elasticsearch",
       "compatibility_matrix_url": "https://www.elastic.co/guide/en/cloud-on-k8s/2.16/k8s-supported.html",
-      "changelog_location": "https://github.com/elastic/elasticsearch/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/elastic/elasticsearch/releases"
     },
     {
       "name": "EnRoute",
       "project_url": "https://getenroute.io/",
       "repository": "https://github.com/saarasio/enroute",
       "compatibility_matrix_url": "https://github.com/saarasio/enroute#prerequisites",
-      "changelog_location": "https://github.com/saarasio/enroute/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/saarasio/enroute/releases"
     },
     {
       "name": "FD.io (VPP)",
       "project_url": "https://fd.io/",
       "repository": "https://github.com/FDio/vpp",
       "compatibility_matrix_url": "https://fd.io/vppproject/vpprelease/",
-      "changelog_location": "https://github.com/FDio/vpp/blob/master/RELEASE.md",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/FDio/vpp/blob/master/RELEASE.md"
     },
     {
       "name": "FOSSA CLI",
       "project_url": "https://fossa.com/",
       "repository": "https://github.com/fossas/fossa-cli",
       "compatibility_matrix_url": "https://github.com/fossas/fossa-cli/blob/master/README.md",
-      "changelog_location": "https://github.com/fossas/fossa-cli/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/fossas/fossa-cli/releases"
     },
     {
       "name": "Foniod",
       "project_url": "https://foniod.org/",
       "repository": "https://github.com/foniod/foniod",
       "compatibility_matrix_url": "https://github.com/foniod/foniod#supported-platforms",
-      "changelog_location": "https://github.com/foniod/foniod/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/foniod/foniod/releases"
     },
     {
       "name": "InfluxData (InfluxDB)",
       "project_url": "https://www.influxdata.com/",
       "repository": "https://github.com/influxdata/influxdb",
       "compatibility_matrix_url": "https://docs.influxdata.com/influxdb/latest/install/?t=Kubernetes",
-      "changelog_location": "https://github.com/influxdata/influxdb/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/influxdata/influxdb/releases"
     },
     {
       "name": "Ligato (VPP Agent)",
       "project_url": "https://ligato.io/",
       "repository": "https://github.com/ligato/vpp-agent",
       "compatibility_matrix_url": "https://docs.ligato.io/en/latest/user-guide/references/",
-      "changelog_location": "https://github.com/ligato/vpp-agent/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/ligato/vpp-agent/releases"
     },
     {
       "name": "Ligato VPP Agent",
       "project_url": "https://ligato.io/",
       "repository": "https://github.com/ligato/vpp-agent",
       "compatibility_matrix_url": "https://docs.ligato.io/en/latest/user-guide/get-vpp-agent/",
-      "changelog_location": "https://github.com/ligato/vpp-agent/blob/master/CHANGELOG.md",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/ligato/vpp-agent/blob/master/CHANGELOG.md"
     },
     {
       "name": "Notary Project (notation)",
       "project_url": "https://notaryproject.dev/",
       "repository": "https://github.com/notaryproject/notation",
       "compatibility_matrix_url": "https://notaryproject.dev/docs/user-guides/installation/",
-      "changelog_location": "https://github.com/notaryproject/notation/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/notaryproject/notation/releases"
     },
     {
       "name": "OPAL",
       "project_url": "https://www.opal.dev/",
       "repository": "https://github.com/permitio/opal",
       "compatibility_matrix_url": "https://docs.opal.ac/getting-started/running-opal/overview",
-      "changelog_location": "https://github.com/permitio/opal/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/permitio/opal/releases"
     },
     {
       "name": "OpenTracing (Go)",
       "project_url": "https://opentracing.io/",
       "repository": "https://github.com/opentracing/opentracing-go",
       "compatibility_matrix_url": "https://github.com/opentracing/opentracing-go/blob/master/README.md",
-      "changelog_location": "https://github.com/opentracing/opentracing-go/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/opentracing/opentracing-go/releases"
     },
     {
       "name": "Sentinel (Alibaba)",
       "project_url": "https://sentinelguard.io/",
       "repository": "https://github.com/alibaba/Sentinel",
       "compatibility_matrix_url": "https://github.com/alibaba/Sentinel/wiki/Guideline:-Kubernetes",
-      "changelog_location": "https://github.com/alibaba/Sentinel/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/alibaba/Sentinel/releases"
     },
     {
       "name": "Swift (OpenStack)",
       "project_url": "https://docs.openstack.org/swift/latest/",
       "repository": "https://github.com/openstack/swift",
       "compatibility_matrix_url": "https://docs.openstack.org/swift/latest/associated_projects.html",
-      "changelog_location": "https://github.com/openstack/swift/blob/master/CHANGELOG",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/openstack/swift/blob/master/CHANGELOG"
     },
     {
       "name": "Triton Object Storage (Manta)",
       "project_url": "https://www.tritondatacenter.com/",
       "repository": "https://github.com/TritonDataCenter/manta",
       "compatibility_matrix_url": "https://github.com/TritonDataCenter/manta/blob/master/docs/operator-guide/deployment.md",
-      "changelog_location": "https://github.com/TritonDataCenter/manta/blob/master/CHANGES.md",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/TritonDataCenter/manta/blob/master/CHANGES.md"
     },
     {
       "name": "bRPC",
       "project_url": "https://brpc.apache.org/",
       "repository": "https://github.com/apache/brpc",
       "compatibility_matrix_url": "https://github.com/apache/brpc#supported-platforms",
-      "changelog_location": "https://github.com/apache/brpc/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/apache/brpc/releases"
     },
     {
       "name": "gocrane/Crane",
       "project_url": "https://gocrane.io/",
       "repository": "https://github.com/gocrane/crane",
       "compatibility_matrix_url": "https://gocrane.io/docs/getting-started/installation/",
-      "changelog_location": "https://github.com/gocrane/crane/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/gocrane/crane/releases"
     },
     {
       "name": "harmonycloud/Kindling",
       "project_url": "https://kindling.harmonycloud.cn/",
       "repository": "https://github.com/KindlingProject/kindling",
       "compatibility_matrix_url": "https://github.com/KindlingProject/kindling#requirements",
-      "changelog_location": "https://github.com/KindlingProject/kindling/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/KindlingProject/kindling/releases"
     },
     {
       "name": "Azure API Management Self-Hosted Gateway",
       "project_url": "https://learn.microsoft.com/en-us/azure/api-management/self-hosted-gateway-overview",
       "repository": "https://github.com/azure/api-management",
       "compatibility_matrix_url": "https://learn.microsoft.com/en-us/azure/api-management/self-hosted-gateway-overview#kubernetes-support",
-      "changelog_location": "https://github.com/Azure/api-management/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/Azure/api-management/releases"
     },
     {
       "name": "Hango Gateway",
       "project_url": "https://github.com/hango-io/hango-gateway",
       "repository": "https://github.com/hango-io/hango-gateway",
       "compatibility_matrix_url": "https://github.com/hango-io/hango-gateway/blob/master/README.md",
-      "changelog_location": "https://github.com/hango-io/hango-gateway/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/hango-io/hango-gateway/releases"
     },
     {
       "name": "Membrane API Gateway",
       "project_url": "https://membrane-soa.org/",
       "repository": "https://github.com/membrane/api-gateway",
       "compatibility_matrix_url": "https://github.com/membrane/api-gateway/blob/master/README.md",
-      "changelog_location": "https://github.com/membrane/api-gateway/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/membrane/api-gateway/releases"
     },
     {
       "name": "MuleSoft Mule Runtime",
       "project_url": "https://www.mulesoft.com/",
       "repository": "https://github.com/mulesoft/mule",
       "compatibility_matrix_url": "https://docs.mulesoft.com/release-notes/",
-      "changelog_location": "https://github.com/mulesoft/mule/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/mulesoft/mule/releases"
     },
     {
       "name": "Cert-Manager Trust Manager",
       "project_url": "https://cert-manager.io/docs/trust/trust-manager/",
       "repository": "https://github.com/cert-manager/trust-manager",
       "compatibility_matrix_url": "https://cert-manager.io/docs/trust/trust-manager/#supported-kubernetes-versions",
-      "changelog_location": "https://github.com/cert-manager/trust-manager/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/cert-manager/trust-manager/releases"
     },
     {
       "name": "Kustomize",
       "project_url": "https://kustomize.io/",
       "repository": "https://github.com/kubernetes-sigs/kustomize",
       "compatibility_matrix_url": "https://kubectl.docs.kubernetes.io/installation/kustomize/",
-      "changelog_location": "https://github.com/kubernetes-sigs/kustomize/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubernetes-sigs/kustomize/releases"
     },
     {
       "name": "Reloader",
       "project_url": "https://github.com/stakater/Reloader",
       "repository": "https://github.com/stakater/Reloader",
       "compatibility_matrix_url": "https://github.com/stakater/Reloader#compatibility",
-      "changelog_location": "https://github.com/stakater/Reloader/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/stakater/Reloader/releases"
     },
     {
       "name": "Crane (gocrane)",
       "project_url": "https://gocrane.io/",
       "repository": "https://github.com/gocrane/crane",
       "compatibility_matrix_url": "https://gocrane.io/docs/getting-started/installation/",
-      "changelog_location": "https://github.com/gocrane/crane/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/gocrane/crane/releases"
     },
     {
       "name": "Keel",
       "project_url": "https://keel.sh/",
       "repository": "https://github.com/keel-sh/keel",
       "compatibility_matrix_url": "https://keel.sh/docs/#prerequisites",
-      "changelog_location": "https://github.com/keel-sh/keel/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/keel-sh/keel/releases"
     },
     {
       "name": "Gateway API",
       "project_url": "https://gateway-api.sigs.k8s.io/",
       "repository": "https://github.com/kubernetes-sigs/gateway-api",
       "compatibility_matrix_url": "https://gateway-api.sigs.k8s.io/implementations/",
-      "changelog_location": "https://github.com/kubernetes-sigs/gateway-api/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubernetes-sigs/gateway-api/releases"
     },
     {
       "name": "Kueue",
       "project_url": "https://kueue.sigs.k8s.io/",
       "repository": "https://github.com/kubernetes-sigs/kueue",
       "compatibility_matrix_url": "https://kueue.sigs.k8s.io/docs/installation/#before-you-begin",
-      "changelog_location": "https://github.com/kubernetes-sigs/kueue/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubernetes-sigs/kueue/releases"
     },
     {
       "name": "KWOK",
       "project_url": "https://kwok.sigs.k8s.io/",
       "repository": "https://github.com/kubernetes-sigs/kwok",
       "compatibility_matrix_url": "https://kwok.sigs.k8s.io/docs/user/installation/",
-      "changelog_location": "https://github.com/kubernetes-sigs/kwok/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubernetes-sigs/kwok/releases"
     },
     {
       "name": "CloudWeGo/Kitex",
       "project_url": "https://www.cloudwego.io/",
       "repository": "https://github.com/cloudwego/kitex",
       "compatibility_matrix_url": "https://www.cloudwego.io/docs/kitex/getting-started/",
-      "changelog_location": "https://github.com/cloudwego/kitex/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/cloudwego/kitex/releases"
     },
     {
       "name": "Descheduler",
       "project_url": "https://github.com/kubernetes-sigs/descheduler",
       "repository": "https://github.com/kubernetes-sigs/descheduler",
       "compatibility_matrix_url": "https://github.com/kubernetes-sigs/descheduler#compatibility-matrix",
-      "changelog_location": "https://github.com/kubernetes-sigs/descheduler/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubernetes-sigs/descheduler/releases"
     },
     {
       "name": "Distribution (Docker Registry)",
       "project_url": "https://distribution.github.io/distribution/",
       "repository": "https://github.com/distribution/distribution",
       "compatibility_matrix_url": "https://distribution.github.io/distribution/about/configuration/",
-      "changelog_location": "https://github.com/distribution/distribution/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/distribution/distribution/releases"
     },
     {
       "name": "Harbor",
       "project_url": "https://goharbor.io/",
       "repository": "https://github.com/goharbor/harbor",
       "compatibility_matrix_url": "https://goharbor.io/docs/latest/install-config/harbor-compatibility-list/",
-      "changelog_location": "https://github.com/goharbor/harbor/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/goharbor/harbor/releases"
     },
     {
       "name": "Zot",
       "project_url": "https://zotregistry.dev/",
       "repository": "https://github.com/project-zot/zot",
       "compatibility_matrix_url": "https://zotregistry.dev/latest/install-guides/install-guide-k8s/",
-      "changelog_location": "https://github.com/project-zot/zot/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/project-zot/zot/releases"
     },
     {
       "name": "Kubeshark",
       "project_url": "https://kubeshark.co/",
       "repository": "https://github.com/kubeshark/kubeshark",
       "compatibility_matrix_url": "https://docs.kubeshark.co/en/install",
-      "changelog_location": "https://github.com/kubeshark/kubeshark/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/kubeshark/kubeshark/releases"
     },
     {
       "name": "Parca",
       "project_url": "https://www.parca.dev/",
       "repository": "https://github.com/parca-dev/parca",
       "compatibility_matrix_url": "https://www.parca.dev/docs/quickstart",
-      "changelog_location": "https://github.com/parca-dev/parca/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/parca-dev/parca/releases"
     },
     {
       "name": "Kubernetes Event Exporter",
       "project_url": "https://github.com/resmoio/kubernetes-event-exporter",
       "repository": "https://github.com/resmoio/kubernetes-event-exporter",
       "compatibility_matrix_url": "https://github.com/resmoio/kubernetes-event-exporter#getting-started",
-      "changelog_location": "https://github.com/resmoio/kubernetes-event-exporter/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/resmoio/kubernetes-event-exporter/releases"
     },
     {
       "name": "Robusta",
       "project_url": "https://home.robusta.dev/",
       "repository": "https://github.com/robusta-dev/robusta",
       "compatibility_matrix_url": "https://docs.robusta.dev/master/setup-robusta/installation/index.html",
-      "changelog_location": "https://github.com/robusta-dev/robusta/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/robusta-dev/robusta/releases"
     },
     {
       "name": "Prometheus Adapter",
       "project_url": "https://github.com/kubernetes-sigs/prometheus-adapter",
       "repository": "https://github.com/kubernetes-sigs/prometheus-adapter",
       "compatibility_matrix_url": "https://github.com/kubernetes-sigs/prometheus-adapter#readme",
-      "changelog_location": "https://github.com/kubernetes-sigs/prometheus-adapter/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubernetes-sigs/prometheus-adapter/releases"
     },
     {
       "name": "kube-state-metrics",
       "project_url": "https://github.com/kubernetes/kube-state-metrics",
       "repository": "https://github.com/kubernetes/kube-state-metrics",
       "compatibility_matrix_url": "https://github.com/kubernetes/kube-state-metrics#compatibility-matrix",
-      "changelog_location": "https://github.com/kubernetes/kube-state-metrics/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubernetes/kube-state-metrics/releases"
     },
     {
       "name": "Goldpinger",
       "project_url": "https://github.com/bloomberg/goldpinger",
       "repository": "https://github.com/bloomberg/goldpinger",
       "compatibility_matrix_url": "https://github.com/bloomberg/goldpinger#readme",
-      "changelog_location": "https://github.com/bloomberg/goldpinger/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/bloomberg/goldpinger/releases"
     },
     {
       "name": "Cilium Hubble",
       "project_url": "https://docs.cilium.io/en/stable/observability/hubble/",
       "repository": "https://github.com/cilium/hubble",
       "compatibility_matrix_url": "https://docs.cilium.io/en/stable/network/kubernetes/compatibility/",
-      "changelog_location": "https://github.com/cilium/hubble/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/cilium/hubble/releases"
     },
     {
       "name": "Pyrra",
       "project_url": "https://github.com/pyrra-dev/pyrra",
       "repository": "https://github.com/pyrra-dev/pyrra",
       "compatibility_matrix_url": "https://github.com/pyrra-dev/pyrra#installation",
-      "changelog_location": "https://github.com/pyrra-dev/pyrra/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/pyrra-dev/pyrra/releases"
     },
     {
       "name": "Sloth",
       "project_url": "https://sloth.dev/",
       "repository": "https://github.com/slok/sloth",
       "compatibility_matrix_url": "https://sloth.dev/introduction/install/",
-      "changelog_location": "https://github.com/slok/sloth/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/slok/sloth/releases"
     },
     {
       "name": "Alertmanager",
       "project_url": "https://prometheus.io/docs/alerting/latest/alertmanager/",
       "repository": "https://github.com/prometheus/alertmanager",
       "compatibility_matrix_url": "https://github.com/prometheus/alertmanager#readme",
-      "changelog_location": "https://github.com/prometheus/alertmanager/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/prometheus/alertmanager/releases"
     },
     {
       "name": "Chaos Mesh",
       "project_url": "https://chaos-mesh.org/",
       "repository": "https://github.com/chaos-mesh/chaos-mesh",
       "compatibility_matrix_url": "https://chaos-mesh.org/docs/#supported-kubernetes-versions",
-      "changelog_location": "https://github.com/chaos-mesh/chaos-mesh/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/chaos-mesh/chaos-mesh/releases"
     },
     {
       "name": "Chaos Toolkit",
       "project_url": "https://chaostoolkit.org/",
       "repository": "https://github.com/chaostoolkit/chaostoolkit",
       "compatibility_matrix_url": "https://chaostoolkit.org/drivers/kubernetes/#compatibility",
-      "changelog_location": "https://github.com/chaostoolkit/chaostoolkit/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/chaostoolkit/chaostoolkit/releases"
     },
     {
       "name": "Chaosblade",
       "project_url": "https://chaosblade.io/",
       "repository": "https://github.com/chaosblade-io/chaosblade",
       "compatibility_matrix_url": "https://chaosblade.io/docs/getting-started/installation-and-deployment/kubernetes-install",
-      "changelog_location": "https://github.com/chaosblade-io/chaosblade/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/chaosblade-io/chaosblade/releases"
     },
     {
       "name": "Gremlin",
       "project_url": "https://www.gremlin.com/",
       "repository": "https://github.com/gremlin/helm",
       "compatibility_matrix_url": "https://www.gremlin.com/docs/reliability-management/install/install-gremlin-kubernetes/",
-      "changelog_location": "https://www.gremlin.com/docs/release-notes/",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://www.gremlin.com/docs/release-notes/"
     },
     {
       "name": "Krkn",
       "project_url": "https://krkn-chaos.github.io/krkn",
       "repository": "https://github.com/krkn-chaos/krkn",
       "compatibility_matrix_url": "https://github.com/krkn-chaos/krkn#supported-platforms",
-      "changelog_location": "https://github.com/krkn-chaos/krkn/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/krkn-chaos/krkn/releases"
     },
     {
       "name": "Kubeinvaders",
       "project_url": "https://github.com/lucky-sideburn/kubeinvaders",
       "repository": "https://github.com/lucky-sideburn/kubeinvaders",
       "compatibility_matrix_url": "https://github.com/lucky-sideburn/kubeinvaders#prerequisites",
-      "changelog_location": "https://github.com/lucky-sideburn/kubeinvaders/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/lucky-sideburn/kubeinvaders/releases"
     },
     {
       "name": "Litmus",
       "project_url": "https://litmuschaos.io/",
       "repository": "https://github.com/litmuschaos/litmus",
       "compatibility_matrix_url": "https://litmuschaos.github.io/litmus/experiments/categories/contents/#platform-support",
-      "changelog_location": "https://github.com/litmuschaos/litmus/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/litmuschaos/litmus/releases"
     },
     {
       "name": "PowerfulSeal",
       "project_url": "https://github.com/powerfulseal/powerfulseal",
       "repository": "https://github.com/powerfulseal/powerfulseal",
       "compatibility_matrix_url": "https://github.com/powerfulseal/powerfulseal#kubernetes-compatibility",
-      "changelog_location": "https://github.com/powerfulseal/powerfulseal/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/powerfulseal/powerfulseal/releases"
     },
     {
       "name": "Steadybit",
       "project_url": "https://steadybit.com/",
       "repository": "https://github.com/steadybit/steadybit",
       "compatibility_matrix_url": "https://docs.steadybit.com/install-and-configure/install-agent/install-on-kubernetes",
-      "changelog_location": "https://github.com/steadybit/steadybit/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/steadybit/steadybit/releases"
     },
     {
       "name": "chaoskube",
       "project_url": "https://github.com/linki/chaoskube",
       "repository": "https://github.com/linki/chaoskube",
       "compatibility_matrix_url": "https://github.com/linki/chaoskube#compatibility",
-      "changelog_location": "https://github.com/linki/chaoskube/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/linki/chaoskube/releases"
     },
     {
       "name": "Infracost",
       "project_url": "https://www.infracost.io/",
       "repository": "https://github.com/infracost/infracost",
       "compatibility_matrix_url": "https://www.infracost.io/docs/integrations/cicd/",
-      "changelog_location": "https://github.com/infracost/infracost/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/infracost/infracost/releases"
     },
     {
       "name": "Karpenter",
       "project_url": "https://karpenter.sh",
       "repository": "https://github.com/kubernetes-sigs/karpenter",
       "compatibility_matrix_url": "https://karpenter.sh/docs/upgrading/compatibility/",
-      "changelog_location": "https://github.com/kubernetes-sigs/karpenter/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubernetes-sigs/karpenter/releases"
     },
     {
       "name": "Kubecost",
       "project_url": "https://www.kubecost.com/",
       "repository": "https://github.com/kubecost/cost-model",
       "compatibility_matrix_url": "https://docs.kubecost.com/install-and-configure/install#kubernetes-cluster-requirements",
-      "changelog_location": "https://github.com/kubecost/cost-model/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubecost/cost-model/releases"
     },
     {
       "name": "OpenCost",
       "project_url": "https://www.opencost.io/",
       "repository": "https://github.com/opencost/opencost",
       "compatibility_matrix_url": "https://www.opencost.io/docs/installation/install#supported-kubernetes-versions",
-      "changelog_location": "https://github.com/opencost/opencost/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/opencost/opencost/releases"
     },
     {
       "name": "gocrane",
       "project_url": "https://gocrane.io/",
       "repository": "https://github.com/gocrane/crane",
       "compatibility_matrix_url": "https://gocrane.io/docs/getting-started/installation/",
-      "changelog_location": "https://github.com/gocrane/crane/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/gocrane/crane/releases"
     },
     {
       "name": "nOps",
       "project_url": "https://nops.io",
       "repository": "https://github.com/nops-io/nops-k8s-agent",
       "compatibility_matrix_url": "https://github.com/nops-io/nops-k8s-agent#prerequisites",
-      "changelog_location": "https://github.com/nops-io/nops-k8s-agent/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/nops-io/nops-k8s-agent/releases"
     },
     {
       "name": "Bucketeer",
       "project_url": "https://bucketeer.io",
       "repository": "https://github.com/bucketeer-io/bucketeer",
       "compatibility_matrix_url": "https://docs.bucketeer.io/getting-started/quickstart",
-      "changelog_location": "https://github.com/bucketeer-io/bucketeer/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/bucketeer-io/bucketeer/releases"
     },
     {
       "name": "FeatureHub",
       "project_url": "https://www.featurehub.io/",
       "repository": "https://github.com/featurehub-io/featurehub",
       "compatibility_matrix_url": "https://docs.featurehub.io/featurehub/latest/installation.html#_kubernetes",
-      "changelog_location": "https://github.com/featurehub-io/featurehub/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/featurehub-io/featurehub/releases"
     },
     {
       "name": "Flagsmith",
       "project_url": "https://www.flagsmith.com/",
       "repository": "https://github.com/Flagsmith/flagsmith",
       "compatibility_matrix_url": "https://docs.flagsmith.com/deployment/hosting/kubernetes",
-      "changelog_location": "https://github.com/Flagsmith/flagsmith/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/Flagsmith/flagsmith/releases"
     },
     {
       "name": "Flipt",
       "project_url": "https://flipt.io",
       "repository": "https://github.com/flipt-io/flipt",
       "compatibility_matrix_url": "https://www.flipt.io/docs/operations/deployment/kubernetes",
-      "changelog_location": "https://github.com/flipt-io/flipt/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/flipt-io/flipt/releases"
     },
     {
       "name": "GO Feature Flag",
       "project_url": "https://gofeatureflag.org",
       "repository": "https://github.com/thomaspoignant/go-feature-flag",
       "compatibility_matrix_url": "https://gofeatureflag.org/docs/configure_flag/store_your_flags/kubernetes",
-      "changelog_location": "https://github.com/thomaspoignant/go-feature-flag/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/thomaspoignant/go-feature-flag/releases"
     },
     {
       "name": "OpenFeature",
       "project_url": "https://openfeature.dev/",
       "repository": "https://github.com/open-feature/spec",
       "compatibility_matrix_url": "https://openfeature.dev/docs/reference/technologies/server/kubernetes",
-      "changelog_location": "https://github.com/open-feature/spec/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/open-feature/spec/releases"
     },
     {
       "name": "Unleash",
       "project_url": "https://www.getunleash.io/",
       "repository": "https://github.com/Unleash/unleash",
       "compatibility_matrix_url": "https://docs.getunleash.io/using-unleash/deploy/getting-started",
-      "changelog_location": "https://github.com/Unleash/unleash/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/Unleash/unleash/releases"
     },
     {
       "name": "Grafana OnCall",
       "project_url": "https://grafana.com/products/oncall/",
       "repository": "https://github.com/grafana/oncall",
       "compatibility_matrix_url": "https://grafana.com/docs/oncall/latest/set-up/open-source/",
-      "changelog_location": "https://github.com/grafana/oncall/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/grafana/oncall/releases"
     },
     {
       "name": "Fluent Bit",
       "project_url": "https://fluentbit.io/",
       "repository": "https://github.com/fluent/fluent-bit",
       "compatibility_matrix_url": "https://docs.fluentbit.io/manual/installation/kubernetes",
-      "changelog_location": "https://github.com/fluent/fluent-bit/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/fluent/fluent-bit/releases"
     },
     {
       "name": "Prometheus Pushgateway",
       "project_url": "https://github.com/prometheus/pushgateway",
       "repository": "https://github.com/prometheus/pushgateway",
       "compatibility_matrix_url": "https://github.com/prometheus/pushgateway#readme",
-      "changelog_location": "https://github.com/prometheus/pushgateway/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/prometheus/pushgateway/releases"
     },
     {
       "name": "Prometheus Blackbox Exporter",
       "project_url": "https://github.com/prometheus/blackbox_exporter",
       "repository": "https://github.com/prometheus/blackbox_exporter",
       "compatibility_matrix_url": "https://github.com/prometheus/blackbox_exporter#readme",
-      "changelog_location": "https://github.com/prometheus/blackbox_exporter/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/prometheus/blackbox_exporter/releases"
     },
     {
       "name": "Datadog Operator",
       "project_url": "https://docs.datadoghq.com/containers/kubernetes/installation/?tab=operator",
       "repository": "https://github.com/DataDog/datadog-operator",
       "compatibility_matrix_url": "https://github.com/DataDog/datadog-operator#readme",
-      "changelog_location": "https://github.com/DataDog/datadog-operator/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/DataDog/datadog-operator/releases"
     },
     {
       "name": "New Relic Kubernetes Integration",
       "project_url": "https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration/",
       "repository": "https://github.com/newrelic/nri-kubernetes",
       "compatibility_matrix_url": "https://docs.newrelic.com/docs/kubernetes-pixie/kubernetes-integration/get-started/kubernetes-integration-compatibility-requirements/",
-      "changelog_location": "https://github.com/newrelic/nri-kubernetes/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/newrelic/nri-kubernetes/releases"
     },
     {
       "name": "Anteon",
       "project_url": "https://getanteon.com/",
       "repository": "https://github.com/getanteon/anteon",
       "compatibility_matrix_url": "https://github.com/getanteon/anteon#prerequisites",
-      "changelog_location": "https://github.com/getanteon/anteon/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/getanteon/anteon/releases"
     },
     {
       "name": "Beats",
       "project_url": "https://www.elastic.co/beats",
       "repository": "https://github.com/elastic/beats",
       "compatibility_matrix_url": "https://www.elastic.co/guide/en/cloud-on-k8s/2.16/k8s-supported.html",
-      "changelog_location": "https://github.com/elastic/beats/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/elastic/beats/releases"
     },
     {
       "name": "Botkube",
       "project_url": "https://www.botkube.io",
       "repository": "https://github.com/kubeshop/botkube",
       "compatibility_matrix_url": "https://docs.botkube.io/configuration/helm-chart#kubernetes-support",
-      "changelog_location": "https://github.com/kubeshop/botkube/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubeshop/botkube/releases"
     },
     {
       "name": "Centreon",
       "project_url": "https://www.centreon.com/",
       "repository": "https://github.com/centreon/centreon",
       "compatibility_matrix_url": "https://docs.centreon.com/docs/installation/compatibility/",
-      "changelog_location": "https://github.com/centreon/centreon/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/centreon/centreon/releases"
     },
     {
       "name": "Checkmk",
       "project_url": "https://checkmk.com/",
       "repository": "https://github.com/Checkmk/checkmk",
       "compatibility_matrix_url": "https://docs.checkmk.com/latest/en/supported_platforms.html",
-      "changelog_location": "https://github.com/Checkmk/checkmk/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/Checkmk/checkmk/releases"
     },
     {
       "name": "Coroot",
       "project_url": "https://coroot.com/",
       "repository": "https://github.com/coroot/coroot",
       "compatibility_matrix_url": "https://coroot.com/docs/getting-started/kubernetes/",
-      "changelog_location": "https://github.com/coroot/coroot/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/coroot/coroot/releases"
     },
     {
       "name": "Cortex",
       "project_url": "https://cortexmetrics.io/",
       "repository": "https://github.com/cortexproject/cortex",
       "compatibility_matrix_url": "https://cortexmetrics.io/docs/guides/running-cortex-on-kubernetes/",
-      "changelog_location": "https://github.com/cortexproject/cortex/blob/master/CHANGELOG.md",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/cortexproject/cortex/blob/master/CHANGELOG.md"
     },
     {
       "name": "DeepFlow",
       "project_url": "https://deepflow.yunshan.net/community.html",
       "repository": "https://github.com/deepflowys/deepflow",
       "compatibility_matrix_url": "https://deepflow.io/docs/ce-install/overview/",
-      "changelog_location": "https://github.com/deepflowys/deepflow/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/deepflowys/deepflow/releases"
     },
     {
       "name": "EaseAgent",
       "project_url": "https://github.com/megaease/easeagent",
       "repository": "https://github.com/megaease/easeagent",
       "compatibility_matrix_url": "https://github.com/megaease/easeagent#requirements",
-      "changelog_location": "https://github.com/megaease/easeagent/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/megaease/easeagent/releases"
     },
     {
       "name": "Elastic",
       "project_url": "https://www.elastic.co/",
       "repository": "https://github.com/elastic/elasticsearch",
       "compatibility_matrix_url": "https://www.elastic.co/guide/en/cloud-on-k8s/2.16/k8s-supported.html",
-      "changelog_location": "https://github.com/elastic/elasticsearch/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/elastic/elasticsearch/releases"
     },
     {
       "name": "Elastic APM",
       "project_url": "https://www.elastic.co/observability/application-performance-monitoring",
       "repository": "https://github.com/elastic/apm-server",
       "compatibility_matrix_url": "https://www.elastic.co/guide/en/cloud-on-k8s/2.16/k8s-supported.html",
-      "changelog_location": "https://github.com/elastic/apm-server/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/elastic/apm-server/releases"
     },
     {
       "name": "Embrace",
       "project_url": "https://embrace.io/",
       "repository": "https://github.com/embrace-io/embrace-apple-sdk",
       "compatibility_matrix_url": "https://github.com/embrace-io/embrace-apple-sdk#requirements",
-      "changelog_location": "https://github.com/embrace-io/embrace-apple-sdk/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/embrace-io/embrace-apple-sdk/releases"
     },
     {
       "name": "Falcon",
       "project_url": "https://github.com/open-falcon/falcon-plus",
       "repository": "https://github.com/open-falcon/falcon-plus",
       "compatibility_matrix_url": "https://github.com/open-falcon/falcon-plus#readme",
-      "changelog_location": "https://github.com/open-falcon/falcon-plus/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/open-falcon/falcon-plus/releases"
     },
     {
       "name": "Fluentd",
       "project_url": "https://www.fluentd.org/",
       "repository": "https://github.com/fluent/fluentd",
       "compatibility_matrix_url": "https://docs.fluentd.org/container-deployment/kubernetes",
-      "changelog_location": "https://github.com/fluent/fluentd/blob/master/CHANGELOG.md",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/fluent/fluentd/blob/master/CHANGELOG.md"
     },
     {
       "name": "Fonio",
       "project_url": "https://ingraind.org/",
       "repository": "https://github.com/foniod/foniod",
       "compatibility_matrix_url": "https://github.com/foniod/foniod#supported-platforms",
-      "changelog_location": "https://github.com/foniod/foniod/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/foniod/foniod/releases"
     },
     {
       "name": "Gonzo",
       "project_url": "https://www.controltheory.com/gonzo/",
       "repository": "https://github.com/control-theory/gonzo",
       "compatibility_matrix_url": "https://github.com/control-theory/gonzo#readme",
-      "changelog_location": "https://github.com/control-theory/gonzo/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/control-theory/gonzo/releases"
     },
     {
       "name": "Grafana",
       "project_url": "https://grafana.com/",
       "repository": "https://github.com/grafana/grafana",
       "compatibility_matrix_url": "https://grafana.com/docs/grafana/latest/setup-grafana/installation/kubernetes/",
-      "changelog_location": "https://github.com/grafana/grafana/blob/main/CHANGELOG.md",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/grafana/grafana/blob/main/CHANGELOG.md"
     },
     {
       "name": "Grafana Loki",
       "project_url": "https://grafana.com/oss/loki",
       "repository": "https://github.com/grafana/loki",
       "compatibility_matrix_url": "https://grafana.com/docs/loki/latest/setup/install/helm/reference/",
-      "changelog_location": "https://github.com/grafana/loki/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/grafana/loki/releases"
     },
     {
       "name": "Grafana Mimir",
       "project_url": "https://grafana.com/oss/mimir",
       "repository": "https://github.com/grafana/mimir",
       "compatibility_matrix_url": "https://grafana.com/docs/mimir/latest/set-up/deployment-mode/",
-      "changelog_location": "https://github.com/grafana/mimir/blob/main/CHANGELOG.md",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/grafana/mimir/blob/main/CHANGELOG.md"
     },
     {
       "name": "Grafana Pyroscope",
       "project_url": "https://grafana.com/oss/pyroscope",
       "repository": "https://github.com/grafana/pyroscope",
       "compatibility_matrix_url": "https://grafana.com/docs/pyroscope/latest/deploy-kubernetes/",
-      "changelog_location": "https://github.com/grafana/pyroscope/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/grafana/pyroscope/releases"
     },
     {
       "name": "Grafana Tempo",
       "project_url": "https://grafana.com/oss/tempo/",
       "repository": "https://github.com/grafana/tempo",
       "compatibility_matrix_url": "https://grafana.com/docs/tempo/latest/setup/helm-chart/",
-      "changelog_location": "https://github.com/grafana/tempo/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/grafana/tempo/releases"
     },
     {
       "name": "Graphite",
       "project_url": "https://graphiteapp.org/",
       "repository": "https://github.com/graphite-project/graphite-web",
       "compatibility_matrix_url": "https://graphite.readthedocs.io/en/latest/install.html",
-      "changelog_location": "https://github.com/graphite-project/graphite-web/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/graphite-project/graphite-web/releases"
     },
     {
       "name": "Graylog",
       "project_url": "https://www.graylog.org/",
       "repository": "https://github.com/Graylog2/graylog2-server",
       "compatibility_matrix_url": "https://go2docs.graylog.org/current/what_more_can_graylog_do_for_me/installing_graylog_on_kubernetes.html",
-      "changelog_location": "https://github.com/Graylog2/graylog2-server/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/Graylog2/graylog2-server/releases"
     },
     {
       "name": "Headlamp",
       "project_url": "https://headlamp.dev",
       "repository": "https://github.com/kubernetes-sigs/headlamp",
       "compatibility_matrix_url": "https://headlamp.dev/docs/latest/installation/#compatibility",
-      "changelog_location": "https://github.com/kubernetes-sigs/headlamp/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubernetes-sigs/headlamp/releases"
     },
     {
       "name": "HertzBeat",
       "project_url": "https://hertzbeat.apache.org/",
       "repository": "https://github.com/apache/hertzbeat",
       "compatibility_matrix_url": "https://hertzbeat.apache.org/docs/start/kubernetes-deploy",
-      "changelog_location": "https://github.com/apache/hertzbeat/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/apache/hertzbeat/releases"
     },
     {
       "name": "HolmesGPT",
       "project_url": "https://holmesgpt.dev",
       "repository": "https://github.com/HolmesGPT/holmesgpt",
       "compatibility_matrix_url": "https://github.com/HolmesGPT/holmesgpt#prerequisites",
-      "changelog_location": "https://github.com/HolmesGPT/holmesgpt/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/HolmesGPT/holmesgpt/releases"
     },
     {
       "name": "Hubble",
       "project_url": "https://github.com/cilium/hubble",
       "repository": "https://github.com/cilium/hubble",
       "compatibility_matrix_url": "https://docs.cilium.io/en/stable/network/hubble/setup/",
-      "changelog_location": "https://github.com/cilium/hubble/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/cilium/hubble/releases"
     },
     {
       "name": "Icinga",
       "project_url": "https://icinga.com/",
       "repository": "https://github.com/Icinga/icinga2",
       "compatibility_matrix_url": "https://icinga.com/docs/icinga-2/latest/doc/02-installation/",
-      "changelog_location": "https://github.com/Icinga/icinga2/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/Icinga/icinga2/releases"
     },
     {
       "name": "Inspektor Gadget",
       "project_url": "https://inspektor-gadget.io/",
       "repository": "https://github.com/inspektor-gadget/inspektor-gadget",
       "compatibility_matrix_url": "https://www.inspektor-gadget.io/docs/latest/reference/requirements/",
-      "changelog_location": "https://github.com/inspektor-gadget/inspektor-gadget/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/inspektor-gadget/inspektor-gadget/releases"
     },
     {
       "name": "Jaeger",
       "project_url": "https://www.jaegertracing.io/",
       "repository": "https://github.com/jaegertracing/jaeger",
       "compatibility_matrix_url": "https://github.com/jaegertracing/jaeger-operator/blob/main/COMPATIBILITY.md",
-      "changelog_location": "https://github.com/jaegertracing/jaeger/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/jaegertracing/jaeger/releases"
     },
     {
       "name": "K8sGPT",
       "project_url": "https://www.k8sgpt.ai",
       "repository": "https://github.com/k8sgpt-ai/k8sgpt",
       "compatibility_matrix_url": "https://docs.k8sgpt.ai/getting-started/installation/",
-      "changelog_location": "https://github.com/k8sgpt-ai/k8sgpt/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/k8sgpt-ai/k8sgpt/releases"
     },
     {
       "name": "Keep",
       "project_url": "https://www.keephq.dev/",
       "repository": "https://github.com/keephq/keep",
       "compatibility_matrix_url": "https://docs.keephq.dev/deployment/kubernetes",
-      "changelog_location": "https://github.com/keephq/keep/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/keephq/keep/releases"
     },
     {
       "name": "Kepler",
       "project_url": "https://sustainable-computing.io/",
       "repository": "https://github.com/sustainable-computing-io/kepler",
       "compatibility_matrix_url": "https://sustainable-computing.io/installation/kepler-helm/",
-      "changelog_location": "https://github.com/sustainable-computing-io/kepler/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/sustainable-computing-io/kepler/releases"
     },
     {
       "name": "Kiali",
       "project_url": "https://www.kiali.io/",
       "repository": "https://github.com/kiali/kiali",
       "compatibility_matrix_url": "https://kiali.io/docs/installation/installation-guide/#prerequisites",
-      "changelog_location": "https://github.com/kiali/kiali/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/kiali/kiali/releases"
     },
     {
       "name": "KubeReport",
       "project_url": "https://kubesuite.org/",
       "repository": "https://github.com/kubesuiteorg/kubereport",
       "compatibility_matrix_url": "https://github.com/kubesuiteorg/kubereport#prerequisites",
-      "changelog_location": "https://github.com/kubesuiteorg/kubereport/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubesuiteorg/kubereport/releases"
     },
     {
       "name": "KubeSkoop",
       "project_url": "https://kubeskoop.io",
       "repository": "https://github.com/alibaba/kubeskoop",
       "compatibility_matrix_url": "https://github.com/alibaba/kubeskoop#prerequisites",
-      "changelog_location": "https://github.com/alibaba/kubeskoop/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/alibaba/kubeskoop/releases"
     },
     {
       "name": "Kuberhealthy",
       "project_url": "https://github.com/kuberhealthy/kuberhealthy",
       "repository": "https://github.com/kuberhealthy/kuberhealthy",
       "compatibility_matrix_url": "https://github.com/kuberhealthy/kuberhealthy#compatibility",
-      "changelog_location": "https://github.com/kuberhealthy/kuberhealthy/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kuberhealthy/kuberhealthy/releases"
     },
     {
       "name": "Kubetail",
       "project_url": "https://www.kubetail.com",
       "repository": "https://github.com/kubetail-org/kubetail",
       "compatibility_matrix_url": "https://github.com/kubetail-org/kubetail#requirements",
-      "changelog_location": "https://github.com/kubetail-org/kubetail/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubetail-org/kubetail/releases"
     },
     {
       "name": "LinDB",
       "project_url": "https://www.lindb.io/",
       "repository": "https://github.com/lindb/lindb",
       "compatibility_matrix_url": "https://github.com/lindb/lindb#readme",
-      "changelog_location": "https://github.com/lindb/lindb/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/lindb/lindb/releases"
     },
     {
       "name": "Loggie",
       "project_url": "https://github.com/loggie-io/loggie",
       "repository": "https://github.com/loggie-io/loggie",
       "compatibility_matrix_url": "https://github.com/loggie-io/loggie#readme",
-      "changelog_location": "https://github.com/loggie-io/loggie/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/loggie-io/loggie/releases"
     },
     {
       "name": "Logging Operator (Kube Logging)",
       "project_url": "https://kube-logging.dev/",
       "repository": "https://github.com/kube-logging/logging-operator",
       "compatibility_matrix_url": "https://kube-logging.dev/docs/#supported-kubernetes-versions",
-      "changelog_location": "https://github.com/kube-logging/logging-operator/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kube-logging/logging-operator/releases"
     },
     {
       "name": "Logstash",
       "project_url": "https://www.elastic.co/logstash",
       "repository": "https://github.com/elastic/logstash",
       "compatibility_matrix_url": "https://www.elastic.co/guide/en/cloud-on-k8s/2.16/k8s-supported.html",
-      "changelog_location": "https://github.com/elastic/logstash/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/elastic/logstash/releases"
     },
     {
       "name": "M3",
       "project_url": "https://www.m3db.io/",
       "repository": "https://github.com/m3db/m3",
       "compatibility_matrix_url": "https://m3db.io/docs/operator/",
-      "changelog_location": "https://github.com/m3db/m3/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/m3db/m3/releases"
     },
     {
       "name": "Mermin",
       "project_url": "https://github.com/elastiflow/mermin",
       "repository": "https://github.com/elastiflow/mermin",
       "compatibility_matrix_url": "https://github.com/elastiflow/mermin#readme",
-      "changelog_location": "https://github.com/elastiflow/mermin/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/elastiflow/mermin/releases"
     },
     {
       "name": "Micrometer",
       "project_url": "https://micrometer.io/",
       "repository": "https://github.com/micrometer-metrics/micrometer",
       "compatibility_matrix_url": "https://micrometer.io/docs/installing",
-      "changelog_location": "https://github.com/micrometer-metrics/micrometer/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/micrometer-metrics/micrometer/releases"
     },
     {
       "name": "Monocle",
       "project_url": "https://monocle2ai.org/",
       "repository": "https://github.com/monocle2ai/monocle",
       "compatibility_matrix_url": "https://github.com/monocle2ai/monocle#readme",
-      "changelog_location": "https://github.com/monocle2ai/monocle/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/monocle2ai/monocle/releases"
     },
     {
       "name": "Nagios",
       "project_url": "https://www.nagios.com/",
       "repository": "https://github.com/NagiosEnterprises/nagioscore",
       "compatibility_matrix_url": "https://www.nagios.org/projects/nagios-core/",
-      "changelog_location": "https://github.com/NagiosEnterprises/nagioscore/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/NagiosEnterprises/nagioscore/releases"
     },
     {
       "name": "Netdata",
       "project_url": "https://www.netdata.cloud",
       "repository": "https://github.com/netdata/netdata",
       "compatibility_matrix_url": "https://learn.netdata.cloud/docs/netdata-agent/installation/kubernetes/",
-      "changelog_location": "https://github.com/netdata/netdata/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/netdata/netdata/releases"
     },
     {
       "name": "Netis",
       "project_url": "https://wordpress.com/browsehappy",
       "repository": "https://github.com/Netis/packet-agent",
       "compatibility_matrix_url": "https://github.com/Netis/packet-agent#readme",
-      "changelog_location": "https://github.com/Netis/packet-agent/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/Netis/packet-agent/releases"
     },
     {
       "name": "NexClipper",
       "project_url": "https://github.com/NexClipper/NexClipper?tab=readme-ov-file",
       "repository": "https://github.com/NexClipper/NexClipper",
       "compatibility_matrix_url": "https://github.com/NexClipper/NexClipper#prerequisites",
-      "changelog_location": "https://github.com/NexClipper/NexClipper/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/NexClipper/NexClipper/releases"
     },
     {
       "name": "Nightingale",
       "project_url": "https://n9e.github.io/",
       "repository": "https://github.com/didi/nightingale",
       "compatibility_matrix_url": "https://github.com/didi/nightingale#installation",
-      "changelog_location": "https://github.com/didi/nightingale/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/didi/nightingale/releases"
     },
     {
       "name": "Odigos",
       "project_url": "https://odigos.io",
       "repository": "https://github.com/odigos-io/odigos",
       "compatibility_matrix_url": "https://docs.odigos.io/intro#prerequisites",
-      "changelog_location": "https://github.com/odigos-io/odigos/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/odigos-io/odigos/releases"
     },
     {
       "name": "OpenLIT",
       "project_url": "https://openlit.io/",
       "repository": "https://github.com/openlit/openlit",
       "compatibility_matrix_url": "https://docs.openlit.io/latest/installation/kubernetes",
-      "changelog_location": "https://github.com/openlit/openlit/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/openlit/openlit/releases"
     },
     {
       "name": "OpenLLMetry",
       "project_url": "https://openllmetry.com/",
       "repository": "https://github.com/traceloop/openllmetry",
       "compatibility_matrix_url": "https://github.com/traceloop/openllmetry#readme",
-      "changelog_location": "https://github.com/traceloop/openllmetry/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/traceloop/openllmetry/releases"
     },
     {
       "name": "OpenMetrics",
       "project_url": "https://openmetrics.io/",
       "repository": "https://github.com/OpenObservability/OpenMetrics",
       "compatibility_matrix_url": "https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md",
-      "changelog_location": "https://github.com/OpenObservability/OpenMetrics/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/OpenObservability/OpenMetrics/releases"
     },
     {
       "name": "OpenObserve",
       "project_url": "https://openobserve.ai/",
       "repository": "https://github.com/openobserve/openobserve",
       "compatibility_matrix_url": "https://openobserve.ai/docs/quickstart/#kubernetes",
-      "changelog_location": "https://github.com/openobserve/openobserve/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/openobserve/openobserve/releases"
     },
     {
       "name": "OpenSearch",
       "project_url": "https://opensearch.org",
       "repository": "https://github.com/opensearch-project/opensearch",
       "compatibility_matrix_url": "https://opensearch.org/docs/latest/install-and-configure/install-opensearch/helm/#kubernetes-version-compatibility",
-      "changelog_location": "https://github.com/opensearch-project/OpenSearch/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/opensearch-project/OpenSearch/releases"
     },
     {
       "name": "OpenTSDB",
       "project_url": "https://opentsdb.net/",
       "repository": "https://github.com/OpenTSDB/opentsdb",
       "compatibility_matrix_url": "https://github.com/OpenTSDB/opentsdb/blob/master/README.md",
-      "changelog_location": "https://github.com/OpenTSDB/opentsdb/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/OpenTSDB/opentsdb/releases"
     },
     {
       "name": "OpenTelemetry",
       "project_url": "https://opentelemetry.io/",
       "repository": "https://github.com/open-telemetry/community",
       "compatibility_matrix_url": "https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/compatibility.md",
-      "changelog_location": "https://github.com/open-telemetry/opentelemetry-collector/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/open-telemetry/opentelemetry-collector/releases"
     },
     {
       "name": "OpenTracing",
       "project_url": "https://opentracing.io/",
       "repository": "https://github.com/opentracing/opentracing-go",
       "compatibility_matrix_url": "https://github.com/opentracing/opentracing-go/blob/master/README.md",
-      "changelog_location": "https://github.com/opentracing/opentracing-go/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/opentracing/opentracing-go/releases"
     },
     {
       "name": "Parseable",
       "project_url": "https://www.parseable.io",
       "repository": "https://github.com/parseablehq/parseable",
       "compatibility_matrix_url": "https://www.parseable.com/docs/installation/kubernetes",
-      "changelog_location": "https://github.com/parseablehq/parseable/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/parseablehq/parseable/releases"
     },
     {
       "name": "Perses",
       "project_url": "https://perses.dev",
       "repository": "https://github.com/perses/perses",
       "compatibility_matrix_url": "https://github.com/perses/perses/blob/main/README.md",
-      "changelog_location": "https://github.com/perses/perses/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/perses/perses/releases"
     },
     {
       "name": "Pinpoint",
       "project_url": "https://pinpoint-apm.github.io/pinpoint/",
       "repository": "https://github.com/pinpoint-apm/pinpoint",
       "compatibility_matrix_url": "https://pinpoint-apm.gitbook.io/pinpoint/getting-started/supported-modules",
-      "changelog_location": "https://github.com/pinpoint-apm/pinpoint/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/pinpoint-apm/pinpoint/releases"
     },
     {
       "name": "Pixie",
       "project_url": "https://px.dev/",
       "repository": "https://github.com/pixie-io/pixie",
       "compatibility_matrix_url": "https://docs.px.dev/installing-pixie/requirements/",
-      "changelog_location": "https://github.com/pixie-io/pixie/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/pixie-io/pixie/releases"
     },
     {
       "name": "Prometheus",
       "project_url": "https://prometheus.io/",
       "repository": "https://github.com/prometheus/prometheus",
       "compatibility_matrix_url": "https://prometheus-operator.dev/docs/getting-started/compatibility/",
-      "changelog_location": "https://github.com/prometheus/prometheus/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/prometheus/prometheus/releases"
     },
     {
       "name": "Quickwit",
       "project_url": "https://quickwit.io/",
       "repository": "https://github.com/quickwit-oss/quickwit",
       "compatibility_matrix_url": "https://quickwit.io/docs/deployment/kubernetes",
-      "changelog_location": "https://github.com/quickwit-oss/quickwit/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/quickwit-oss/quickwit/releases"
     },
     {
       "name": "SOFATracer",
       "project_url": "https://www.sofastack.tech/en/",
       "repository": "https://github.com/sofastack/sofa-tracer",
       "compatibility_matrix_url": "https://github.com/sofastack/sofa-tracer#readme",
-      "changelog_location": "https://github.com/sofastack/sofa-tracer/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/sofastack/sofa-tracer/releases"
     },
     {
       "name": "Sensu",
       "project_url": "https://sensu.io/",
       "repository": "https://github.com/sensu/sensu-go",
       "compatibility_matrix_url": "https://docs.sensu.io/sensu-go/latest/platforms/",
-      "changelog_location": "https://github.com/sensu/sensu-go/blob/main/CHANGELOG.md",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/sensu/sensu-go/blob/main/CHANGELOG.md"
     },
     {
       "name": "Sentry",
       "project_url": "https://sentry.io/welcome/",
       "repository": "https://github.com/getsentry/sentry",
       "compatibility_matrix_url": "https://develop.sentry.dev/self-hosted/",
-      "changelog_location": "https://github.com/getsentry/sentry/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/getsentry/sentry/releases"
     },
     {
       "name": "ServiceRadar",
       "project_url": "https://serviceradar.cloud/",
       "repository": "https://github.com/carverauto/serviceradar",
       "compatibility_matrix_url": "https://github.com/carverauto/serviceradar#readme",
-      "changelog_location": "https://github.com/carverauto/serviceradar/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/carverauto/serviceradar/releases"
     },
     {
       "name": "Sidekick",
       "project_url": "https://github.com/runsidekick/sidekick",
       "repository": "https://github.com/runsidekick/sidekick",
       "compatibility_matrix_url": "https://github.com/runsidekick/sidekick#readme",
-      "changelog_location": "https://github.com/runsidekick/sidekick/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/runsidekick/sidekick/releases"
     },
     {
       "name": "SigLens",
       "project_url": "https://www.siglens.com/",
       "repository": "https://github.com/siglens/siglens",
       "compatibility_matrix_url": "https://www.siglens.com/docs/installation/kubernetes",
-      "changelog_location": "https://github.com/siglens/siglens/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/siglens/siglens/releases"
     },
     {
       "name": "Skooner",
       "project_url": "https://skooner.io/",
       "repository": "https://github.com/skooner-k8s/skooner",
       "compatibility_matrix_url": "https://github.com/skooner-k8s/skooner#prerequisites",
-      "changelog_location": "https://github.com/skooner-k8s/skooner/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/skooner-k8s/skooner/releases"
     },
     {
       "name": "SkyWalking",
       "project_url": "https://skywalking.apache.org/",
       "repository": "https://github.com/apache/skywalking",
       "compatibility_matrix_url": "https://skywalking.apache.org/docs/skywalking-helm/latest/readme/#kubernetes-compatibility",
-      "changelog_location": "https://github.com/apache/skywalking/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/apache/skywalking/releases"
     },
     {
       "name": "Spring Cloud Sleuth",
       "project_url": "https://spring.io/projects/spring-cloud-sleuth",
       "repository": "https://github.com/spring-cloud/spring-cloud-sleuth",
       "compatibility_matrix_url": "https://spring.io/projects/spring-cloud-sleuth#support",
-      "changelog_location": "https://github.com/spring-cloud/spring-cloud-sleuth/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/spring-cloud/spring-cloud-sleuth/releases"
     },
     {
       "name": "Thanos",
       "project_url": "https://thanos.io/",
       "repository": "https://github.com/thanos-io/thanos",
       "compatibility_matrix_url": "https://thanos.io/tip/operating/kubernetes.md/",
-      "changelog_location": "https://github.com/thanos-io/thanos/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/thanos-io/thanos/releases"
     },
     {
       "name": "Tracetest",
       "project_url": "https://tracetest.io",
       "repository": "https://github.com/kubeshop/tracetest",
       "compatibility_matrix_url": "https://docs.tracetest.io/getting-started/installation#kubernetes",
-      "changelog_location": "https://github.com/kubeshop/tracetest/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubeshop/tracetest/releases"
     },
     {
       "name": "Trickster",
       "project_url": "https://trickstercache.org",
       "repository": "https://github.com/trickstercache/trickster",
       "compatibility_matrix_url": "https://github.com/trickstercache/trickster/blob/main/README.md",
-      "changelog_location": "https://github.com/trickstercache/trickster/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/trickstercache/trickster/releases"
     },
     {
       "name": "Vector",
       "project_url": "https://vector.dev/",
       "repository": "https://github.com/vectordotdev/vector",
       "compatibility_matrix_url": "https://vector.dev/docs/setup/installation/platforms/kubernetes/",
-      "changelog_location": "https://github.com/vectordotdev/vector/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/vectordotdev/vector/releases"
     },
     {
       "name": "VictoriaMetrics",
       "project_url": "https://victoriametrics.com/",
       "repository": "https://github.com/VictoriaMetrics/VictoriaMetrics",
       "compatibility_matrix_url": "https://docs.victoriametrics.com/operator/setup/#kubernetes-compatibility",
-      "changelog_location": "https://github.com/VictoriaMetrics/VictoriaMetrics/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/VictoriaMetrics/VictoriaMetrics/releases"
     },
     {
       "name": "Zabbix",
       "project_url": "https://www.zabbix.com/",
       "repository": "https://github.com/zabbix/zabbix",
       "compatibility_matrix_url": "https://www.zabbix.com/documentation/current/en/manual/installation/requirements",
-      "changelog_location": "https://github.com/zabbix/zabbix/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/zabbix/zabbix/releases"
     },
     {
       "name": "Zipkin",
       "project_url": "https://zipkin.io/",
       "repository": "https://github.com/openzipkin/zipkin",
       "compatibility_matrix_url": "https://zipkin.io/pages/quickstart",
-      "changelog_location": "https://github.com/openzipkin/zipkin/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/openzipkin/zipkin/releases"
     },
     {
       "name": "harmonycloud",
       "project_url": "https://harmonycloud.cn",
       "repository": "https://github.com/KindlingProject/kindling",
       "compatibility_matrix_url": "https://github.com/KindlingProject/kindling#requirements",
-      "changelog_location": "https://github.com/KindlingProject/kindling/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/KindlingProject/kindling/releases"
     },
     {
       "name": "sysdig",
       "project_url": "https://sysdig.com/opensource/",
       "repository": "https://github.com/draios/sysdig",
       "compatibility_matrix_url": "https://docs.sysdig.com/en/docs/installation/sysdig-agent/agent-installation-requirements/",
-      "changelog_location": "https://github.com/draios/sysdig/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/draios/sysdig/releases"
     },
     {
       "name": "SigNoz",
       "project_url": "https://signoz.io/",
       "repository": "https://github.com/SigNoz/signoz",
       "compatibility_matrix_url": "https://signoz.io/docs/install/kubernetes/",
-      "changelog_location": "https://github.com/SigNoz/signoz/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/SigNoz/signoz/releases"
     },
     {
       "name": "Uptrace",
       "project_url": "https://uptrace.dev/",
       "repository": "https://github.com/uptrace/uptrace",
       "compatibility_matrix_url": "https://uptrace.dev/get/install.html",
-      "changelog_location": "https://github.com/uptrace/uptrace/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/uptrace/uptrace/releases"
     },
     {
       "name": "Grafana Alloy",
       "project_url": "https://grafana.com/docs/alloy/latest/",
       "repository": "https://github.com/grafana/alloy",
       "compatibility_matrix_url": "https://grafana.com/docs/alloy/latest/get-started/install/kubernetes/",
-      "changelog_location": "https://github.com/grafana/alloy/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/grafana/alloy/releases"
     },
     {
       "name": "KUDO",
       "project_url": "https://kudo.dev/",
       "repository": "https://github.com/kudobuilder/kudo",
       "compatibility_matrix_url": "https://kudo.dev/docs/#pre-requisites",
-      "changelog_location": "https://github.com/kudobuilder/kudo/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/kudobuilder/kudo/releases"
     },
     {
       "name": "Metacontroller",
       "project_url": "https://metacontroller.github.io/metacontroller/",
       "repository": "https://github.com/metacontroller/metacontroller",
       "compatibility_matrix_url": "https://metacontroller.github.io/metacontroller/guide/install.html",
-      "changelog_location": "https://github.com/metacontroller/metacontroller/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/metacontroller/metacontroller/releases"
     },
     {
       "name": "Kubebuilder",
       "project_url": "https://book.kubebuilder.io/",
       "repository": "https://github.com/kubernetes-sigs/kubebuilder",
       "compatibility_matrix_url": "https://book.kubebuilder.io/reference/envtest#configuring-envtest-for-integration-tests",
-      "changelog_location": "https://github.com/kubernetes-sigs/kubebuilder/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/kubernetes-sigs/kubebuilder/releases"
     },
     {
       "name": "Operator SDK",
       "project_url": "https://sdk.operatorframework.io/",
       "repository": "https://github.com/operator-framework/operator-sdk",
       "compatibility_matrix_url": "https://sdk.operatorframework.io/docs/installation/#prerequisites",
-      "changelog_location": "https://github.com/operator-framework/operator-sdk/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/operator-framework/operator-sdk/releases"
     },
     {
       "name": "Operator Lifecycle Manager (OLM)",
       "project_url": "https://olm.operatorframework.io/",
       "repository": "https://github.com/operator-framework/operator-lifecycle-manager",
       "compatibility_matrix_url": "https://olm.operatorframework.io/docs/advanced-tasks/version-resolution/",
-      "changelog_location": "https://github.com/operator-framework/operator-lifecycle-manager/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/operator-framework/operator-lifecycle-manager/releases"
     },
     {
       "name": "Kopf",
       "project_url": "https://kopf.readthedocs.io/",
       "repository": "https://github.com/nolar/kopf",
       "compatibility_matrix_url": "https://kopf.readthedocs.io/en/stable/install/",
-      "changelog_location": "https://github.com/nolar/kopf/releases",
-      "upgrade_path_type": "Pip-package"
+      "changelog_location": "https://github.com/nolar/kopf/releases"
     },
     {
       "name": "shell-operator",
       "project_url": "https://github.com/flant/shell-operator",
       "repository": "https://github.com/flant/shell-operator",
       "compatibility_matrix_url": "https://github.com/flant/shell-operator#installation",
-      "changelog_location": "https://github.com/flant/shell-operator/releases",
-      "upgrade_path_type": "Container-image"
+      "changelog_location": "https://github.com/flant/shell-operator/releases"
     },
     {
       "name": "APIOAK",
       "project_url": "https://github.com/apioak/",
       "repository": "https://github.com/apioak/apioak",
       "compatibility_matrix_url": "https://github.com/apioak/apioak/blob/master/README.md",
-      "changelog_location": "https://github.com/apioak/apioak/blob/master/CHANGELOG.md",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/apioak/apioak/blob/master/CHANGELOG.md"
     },
     {
       "name": "APISIX",
       "project_url": "https://apisix.apache.org/",
       "repository": "https://github.com/apache/apisix",
       "compatibility_matrix_url": "https://apisix.apache.org/docs/apisix/installation-guide/",
-      "changelog_location": "https://github.com/apache/apisix/blob/master/CHANGELOG.md",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/apache/apisix/blob/master/CHANGELOG.md"
     },
     {
       "name": "Azure API Management",
       "project_url": "https://azure.microsoft.com/en-us/services/api-management",
       "repository": "https://github.com/azure/api-management",
       "compatibility_matrix_url": "https://learn.microsoft.com/en-us/azure/api-management/self-hosted-gateway-overview#kubernetes-support",
-      "changelog_location": "https://github.com/Azure/api-management/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/Azure/api-management/releases"
     },
     {
       "name": "Easegress",
       "project_url": "https://megaease.com/easegress",
       "repository": "https://github.com/easegress-io/easegress",
       "compatibility_matrix_url": "https://github.com/easegress-io/easegress/blob/main/README.md",
-      "changelog_location": "https://github.com/easegress-io/easegress/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/easegress-io/easegress/releases"
     },
     {
       "name": "Emissary-Ingress",
       "project_url": "https://emissary-ingress.dev/",
       "repository": "https://github.com/emissary-ingress/emissary",
       "compatibility_matrix_url": "https://www.getambassador.io/docs/emissary/latest/topics/install/migration-matrix",
-      "changelog_location": "https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/emissary-ingress/emissary/blob/master/CHANGELOG.md"
     },
     {
       "name": "EnRoute OneStep Ingress",
       "project_url": "https://www.getenroute.io",
       "repository": "https://github.com/saarasio/enroute",
       "compatibility_matrix_url": "https://github.com/saarasio/enroute/blob/master/README.md",
-      "changelog_location": "https://github.com/saarasio/enroute/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/saarasio/enroute/releases"
     },
     {
       "name": "Envoy Gateway",
       "project_url": "https://gateway.envoyproxy.io",
       "repository": "https://github.com/envoyproxy/gateway",
       "compatibility_matrix_url": "https://gateway.envoyproxy.io/docs/install/matrix/",
-      "changelog_location": "https://github.com/envoyproxy/gateway/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/envoyproxy/gateway/releases"
     },
     {
       "name": "Gloo",
       "project_url": "https://www.solo.io",
       "repository": "https://github.com/solo-io/gloo",
       "compatibility_matrix_url": "https://docs.solo.io/gloo-edge/latest/reference/support/",
-      "changelog_location": "https://github.com/solo-io/gloo/blob/main/CHANGELOG.md",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/solo-io/gloo/blob/main/CHANGELOG.md"
     },
     {
       "name": "Gravitee.io",
       "project_url": "https://gravitee.io",
       "repository": "https://github.com/gravitee-io/gravitee-api-management",
       "compatibility_matrix_url": "https://documentation.gravitee.io/apim/overview/plugins-and-api-definitions-support",
-      "changelog_location": "https://github.com/gravitee-io/gravitee-api-management/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/gravitee-io/gravitee-api-management/releases"
     },
     {
       "name": "Hango",
       "project_url": "https://github.com/hango-io",
       "repository": "https://github.com/hango-io/hango-gateway",
       "compatibility_matrix_url": "https://github.com/hango-io/hango-gateway#readme",
-      "changelog_location": "https://github.com/hango-io/hango-gateway/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/hango-io/hango-gateway/releases"
     },
     {
       "name": "Higress",
       "project_url": "https://higress.io",
       "repository": "https://github.com/alibaba/higress",
       "compatibility_matrix_url": "https://higress.io/docs/overview/what-is-higress/",
-      "changelog_location": "https://github.com/alibaba/higress/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/alibaba/higress/releases"
     },
     {
       "name": "Kgateway",
       "project_url": "https://kgateway.dev/",
       "repository": "https://github.com/kgateway-dev/kgateway",
       "compatibility_matrix_url": "https://github.com/kgateway-dev/kgateway/blob/main/README.md",
-      "changelog_location": "https://github.com/kgateway-dev/kgateway/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kgateway-dev/kgateway/releases"
     },
     {
       "name": "Kong",
       "project_url": "https://konghq.com/",
       "repository": "https://github.com/Kong/kong",
       "compatibility_matrix_url": "https://docs.konghq.com/gateway/latest/support-policy/",
-      "changelog_location": "https://github.com/Kong/kong/blob/master/CHANGELOG.md",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/Kong/kong/blob/master/CHANGELOG.md"
     },
     {
       "name": "KrakenD",
       "project_url": "https://www.krakend.io/",
       "repository": "https://github.com/luraproject/lura",
       "compatibility_matrix_url": "https://www.krakend.io/docs/overview/requirements/",
-      "changelog_location": "https://github.com/luraproject/lura/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/luraproject/lura/releases"
     },
     {
       "name": "Kuadrant",
       "project_url": "https://kuadrant.io",
       "repository": "https://github.com/kuadrant/kuadrant-operator",
       "compatibility_matrix_url": "https://docs.kuadrant.io/latest/kuadrant-operator/doc/install/",
-      "changelog_location": "https://github.com/kuadrant/kuadrant-operator/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/kuadrant/kuadrant-operator/releases"
     },
     {
       "name": "KubeGateway",
       "project_url": "https://github.com/kubewharf/kubegateway",
       "repository": "https://github.com/kubewharf/kubegateway",
       "compatibility_matrix_url": "https://github.com/kubewharf/kubegateway/blob/main/README.md",
-      "changelog_location": "https://github.com/kubewharf/kubegateway/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubewharf/kubegateway/releases"
     },
     {
       "name": "Kusk Gateway",
       "project_url": "https://kusk.io/",
       "repository": "https://github.com/kubeshop/kusk-gateway",
       "compatibility_matrix_url": "https://docs.kusk.io/getting-started/installation",
-      "changelog_location": "https://github.com/kubeshop/kusk-gateway/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubeshop/kusk-gateway/releases"
     },
     {
       "name": "Lunar.dev",
       "project_url": "https://www.lunar.dev/",
       "repository": "https://github.com/TheLunarCompany/lunar",
       "compatibility_matrix_url": "https://docs.lunar.dev/installation/kubernetes",
-      "changelog_location": "https://github.com/TheLunarCompany/lunar/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/TheLunarCompany/lunar/releases"
     },
     {
       "name": "Membrane",
       "project_url": "https://www.membrane-api.io/",
       "repository": "https://github.com/membrane/api-gateway",
       "compatibility_matrix_url": "https://github.com/membrane/api-gateway#readme",
-      "changelog_location": "https://github.com/membrane/api-gateway/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/membrane/api-gateway/releases"
     },
     {
       "name": "MuleSoft",
       "project_url": "https://www.mulesoft.com/",
       "repository": "https://github.com/mulesoft/mule",
       "compatibility_matrix_url": "https://github.com/mulesoft/mule#readme",
-      "changelog_location": "https://github.com/mulesoft/mule/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/mulesoft/mule/releases"
     },
     {
       "name": "Reactive Interaction Gateway",
       "project_url": "https://accenture.github.io/reactive-interaction-gateway/",
       "repository": "https://github.com/accenture/reactive-interaction-gateway",
       "compatibility_matrix_url": "https://github.com/Accenture/reactive-interaction-gateway/blob/master/README.md",
-      "changelog_location": "https://github.com/Accenture/reactive-interaction-gateway/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/Accenture/reactive-interaction-gateway/releases"
     },
     {
       "name": "Traefik",
       "project_url": "https://traefik.io/traefik",
       "repository": "https://github.com/traefik/traefik",
       "compatibility_matrix_url": "https://doc.traefik.io/traefik/getting-started/install-traefik/",
-      "changelog_location": "https://github.com/traefik/traefik/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/traefik/traefik/releases"
     },
     {
       "name": "Tyk",
       "project_url": "https://tyk.io/",
       "repository": "https://github.com/TykTechnologies/tyk",
       "compatibility_matrix_url": "https://tyk.io/docs/developer-support/special-releases-and-features/long-term-support-releases/",
-      "changelog_location": "https://github.com/TykTechnologies/tyk/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/TykTechnologies/tyk/releases"
     },
     {
       "name": "WSO2 API Microgateway",
       "project_url": "https://wso2.com/api-manager/api-microgateway",
       "repository": "https://github.com/wso2/product-microgateway",
       "compatibility_matrix_url": "https://apim.docs.wso2.com/en/latest/deploy-and-publish/deploy-on-gateway/choreo-connect/getting-started/deploy/cc-on-kubernetes-with-apim-as-control-plane/",
-      "changelog_location": "https://github.com/wso2/product-microgateway/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/wso2/product-microgateway/releases"
     },
     {
       "name": "ngrok",
       "project_url": "https://ngrok.com",
       "repository": "https://github.com/ngrok/ngrok-go",
       "compatibility_matrix_url": "https://github.com/ngrok/kubernetes-ingress-controller#supported-kubernetes-versions",
-      "changelog_location": "https://github.com/ngrok/ngrok-go/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/ngrok/ngrok-go/releases"
     },
     {
       "name": "KOTS (Replicated)",
       "project_url": "https://kots.io/",
       "repository": "https://github.com/replicatedhq/kots",
       "compatibility_matrix_url": "https://docs.replicated.com/enterprise/installing-existing-cluster-requirements",
-      "changelog_location": "https://github.com/replicatedhq/kots/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/replicatedhq/kots/releases"
     },
     {
       "name": "Velad",
       "project_url": "https://kubevela.io/",
       "repository": "https://github.com/kubevela/kubevela",
       "compatibility_matrix_url": "https://kubevela.io/docs/install",
-      "changelog_location": "https://github.com/kubevela/kubevela/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubevela/kubevela/releases"
     },
     {
       "name": "Dapr",
       "project_url": "https://dapr.io/",
       "repository": "https://github.com/dapr/dapr",
       "compatibility_matrix_url": "https://docs.dapr.io/operations/hosting/kubernetes/kubernetes-deploy/",
-      "changelog_location": "https://github.com/dapr/dapr/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/dapr/dapr/releases"
     },
     {
       "name": "Portainer",
       "project_url": "https://www.portainer.io/",
       "repository": "https://github.com/portainer/portainer",
       "compatibility_matrix_url": "https://docs.portainer.io/start/requirements-and-prerequisites",
-      "changelog_location": "https://github.com/portainer/portainer/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/portainer/portainer/releases"
     },
     {
       "name": "Kcl (KCL Configuration Language)",
       "project_url": "https://kcl-lang.io/",
       "repository": "https://github.com/kcl-lang/kcl",
       "compatibility_matrix_url": "https://kcl-lang.io/docs/user_docs/getting-started/install",
-      "changelog_location": "https://github.com/kcl-lang/kcl/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kcl-lang/kcl/releases"
     },
     {
       "name": "cdk8s",
       "project_url": "https://cdk8s.io/",
       "repository": "https://github.com/cdk8s-team/cdk8s",
       "compatibility_matrix_url": "https://cdk8s.io/docs/latest/getting-started/",
-      "changelog_location": "https://github.com/cdk8s-team/cdk8s/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/cdk8s-team/cdk8s/releases"
     },
     {
       "name": "Upbound",
       "project_url": "https://www.upbound.io/",
       "repository": "https://github.com/upbound/up",
       "compatibility_matrix_url": "https://docs.upbound.io/uxp/install/",
-      "changelog_location": "https://github.com/upbound/up/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/upbound/up/releases"
     },
     {
       "name": "Apache Zookeeper",
       "project_url": "https://zookeeper.apache.org/",
       "repository": "https://github.com/apache/zookeeper",
       "compatibility_matrix_url": "https://hub.docker.com/r/bitnami/zookeeper",
-      "changelog_location": "https://github.com/apache/zookeeper/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/apache/zookeeper/releases"
     },
     {
       "name": "CoreDNS",
       "project_url": "https://coredns.io/",
       "repository": "https://github.com/coredns/coredns",
       "compatibility_matrix_url": "https://github.com/coredns/deployment/blob/master/kubernetes/CoreDNS-k8s_version.md",
-      "changelog_location": "https://github.com/coredns/coredns/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/coredns/coredns/releases"
     },
     {
       "name": "KubeBrain",
       "project_url": "https://github.com/kubewharf/kubebrain",
       "repository": "https://github.com/kubewharf/kubebrain",
       "compatibility_matrix_url": "https://github.com/kubewharf/kubebrain#readme",
-      "changelog_location": "https://github.com/kubewharf/kubebrain/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubewharf/kubebrain/releases"
     },
     {
       "name": "Nacos",
       "project_url": "https://nacos.io/en-us/",
       "repository": "https://github.com/alibaba/nacos",
       "compatibility_matrix_url": "https://nacos.io/docs/latest/quickstart/quick-start-kubernetes/",
-      "changelog_location": "https://github.com/alibaba/nacos/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/alibaba/nacos/releases"
     },
     {
       "name": "Netflix Eureka",
       "project_url": "https://github.com/Netflix/eureka",
       "repository": "https://github.com/Netflix/eureka",
       "compatibility_matrix_url": "https://spring.io/projects/spring-cloud-netflix#support",
-      "changelog_location": "https://github.com/Netflix/eureka/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/Netflix/eureka/releases"
     },
     {
       "name": "Oxia",
       "project_url": "https://oxia-db.github.io",
       "repository": "https://github.com/oxia-db/oxia",
       "compatibility_matrix_url": "https://github.com/oxia-db/oxia#readme",
-      "changelog_location": "https://github.com/oxia-db/oxia/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/oxia-db/oxia/releases"
     },
     {
       "name": "Xline",
       "project_url": "https://www.xline.cloud",
       "repository": "https://github.com/xline-kv/Xline",
       "compatibility_matrix_url": "https://github.com/xline-kv/Xline#readme",
-      "changelog_location": "https://github.com/xline-kv/Xline/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/xline-kv/Xline/releases"
     },
     {
       "name": "etcd",
       "project_url": "https://etcd.io/",
       "repository": "https://github.com/etcd-io/etcd",
       "compatibility_matrix_url": "https://etcd.io/docs/latest/op-guide/supported-platform/",
-      "changelog_location": "https://github.com/etcd-io/etcd/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/etcd-io/etcd/releases"
     },
     {
       "name": "k8gb",
       "project_url": "https://www.k8gb.io",
       "repository": "https://github.com/k8gb-io/k8gb",
       "compatibility_matrix_url": "https://www.k8gb.io/docs/getting_started/",
-      "changelog_location": "https://github.com/k8gb-io/k8gb/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/k8gb-io/k8gb/releases"
     },
     {
       "name": "Argo CD",
       "project_url": "https://argo-cd.readthedocs.io/",
       "repository": "https://github.com/argoproj/argo-cd",
       "compatibility_matrix_url": "https://argo-cd.readthedocs.io/en/stable/operator-manual/installation/#tested-versions",
-      "changelog_location": "https://github.com/argoproj/argo-cd/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/argoproj/argo-cd/releases"
     },
     {
       "name": "Flux",
       "project_url": "https://fluxcd.io/",
       "repository": "https://github.com/fluxcd/flux2",
       "compatibility_matrix_url": "https://fluxcd.io/flux/installation/#prerequisites",
-      "changelog_location": "https://github.com/fluxcd/flux2/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/fluxcd/flux2/releases"
     },
     {
       "name": "Pulumi Kubernetes Operator",
       "project_url": "https://www.pulumi.com/docs/using-pulumi/continuous-delivery/pulumi-kubernetes-operator/",
       "repository": "https://github.com/pulumi/pulumi-kubernetes-operator",
       "compatibility_matrix_url": "https://github.com/pulumi/pulumi-kubernetes-operator#readme",
-      "changelog_location": "https://github.com/pulumi/pulumi-kubernetes-operator/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/pulumi/pulumi-kubernetes-operator/releases"
     },
     {
       "name": "Lens",
       "project_url": "https://k8slens.dev/",
       "repository": "https://github.com/lensapp/lens",
       "compatibility_matrix_url": "https://docs.k8slens.dev/k8slens/getting-started/install-lens/",
-      "changelog_location": "https://github.com/lensapp/lens/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/lensapp/lens/releases"
     },
     {
       "name": "Rancher",
       "project_url": "https://www.rancher.com/",
       "repository": "https://github.com/rancher/rancher",
       "compatibility_matrix_url": "https://www.suse.com/suse-rancher/support-matrix/all-supported-versions/",
-      "changelog_location": "https://github.com/rancher/rancher/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/rancher/rancher/releases"
     },
     {
       "name": "Kopf (Kubernetes Operator Pythonic Framework)",
       "project_url": "https://kopf.readthedocs.io/",
       "repository": "https://github.com/nolar/kopf",
       "compatibility_matrix_url": "https://kopf.readthedocs.io/en/stable/install/",
-      "changelog_location": "https://github.com/nolar/kopf/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/nolar/kopf/releases"
     },
     {
       "name": "Helm",
       "project_url": "https://helm.sh/",
       "repository": "https://github.com/helm/helm",
       "compatibility_matrix_url": "https://helm.sh/docs/topics/version_skew/",
-      "changelog_location": "https://github.com/helm/helm/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/helm/helm/releases"
     },
     {
       "name": "Kratix",
       "project_url": "https://kratix.io/",
       "repository": "https://github.com/syntasso/kratix",
       "compatibility_matrix_url": "https://kratix.io/docs/main/guides/installing-kratix",
-      "changelog_location": "https://github.com/syntasso/kratix/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/syntasso/kratix/releases"
     },
     {
       "name": "Apache Thrift",
       "project_url": "https://thrift.apache.org/",
       "repository": "https://github.com/apache/thrift",
       "compatibility_matrix_url": "https://thrift.apache.org/docs/install/",
-      "changelog_location": "https://github.com/apache/thrift/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/apache/thrift/releases"
     },
     {
       "name": "Apache bRPC",
       "project_url": "https://brpc.apache.org/",
       "repository": "https://github.com/apache/brpc",
       "compatibility_matrix_url": "https://brpc.apache.org/docs/getting_started/",
-      "changelog_location": "https://github.com/apache/brpc/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/apache/brpc/releases"
     },
     {
       "name": "Avro",
       "project_url": "https://avro.apache.org/",
       "repository": "https://github.com/apache/avro",
       "compatibility_matrix_url": "https://avro.apache.org/docs/",
-      "changelog_location": "https://github.com/apache/avro/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/apache/avro/releases"
     },
     {
       "name": "CloudWeGo",
       "project_url": "https://www.cloudwego.io/",
       "repository": "https://github.com/cloudwego/kitex",
       "compatibility_matrix_url": "https://github.com/cloudwego/kitex#requirements",
-      "changelog_location": "https://github.com/cloudwego/kitex/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/cloudwego/kitex/releases"
     },
     {
       "name": "Connect RPC",
       "project_url": "https://connectrpc.com/",
       "repository": "https://github.com/connectrpc/connect-go",
       "compatibility_matrix_url": "https://connectrpc.com/docs/go/getting-started/",
-      "changelog_location": "https://github.com/connectrpc/connect-go/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/connectrpc/connect-go/releases"
     },
     {
       "name": "Dubbo",
       "project_url": "https://dubbo.apache.org/en/",
       "repository": "https://github.com/apache/dubbo",
       "compatibility_matrix_url": "https://dubbo.apache.org/en/overview/what/overview/",
-      "changelog_location": "https://github.com/apache/dubbo/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/apache/dubbo/releases"
     },
     {
       "name": "Easy-Ngo",
       "project_url": "https://netease-media.github.io/easy-ngo-website/",
       "repository": "https://github.com/NetEase-Media/easy-ngo",
       "compatibility_matrix_url": "https://github.com/NetEase-Media/easy-ngo/blob/main/README.md",
-      "changelog_location": "https://github.com/NetEase-Media/easy-ngo/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/NetEase-Media/easy-ngo/releases"
     },
     {
       "name": "GoFr",
       "project_url": "https://gofr.dev/",
       "repository": "https://github.com/gofr-dev/gofr",
       "compatibility_matrix_url": "https://gofr.dev/docs",
-      "changelog_location": "https://github.com/gofr-dev/gofr/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/gofr-dev/gofr/releases"
     },
     {
       "name": "SOFARPC",
       "project_url": "https://www.sofastack.tech/en/",
       "repository": "https://github.com/sofastack/sofa-rpc",
       "compatibility_matrix_url": "https://github.com/sofastack/sofa-rpc#readme",
-      "changelog_location": "https://github.com/sofastack/sofa-rpc/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/sofastack/sofa-rpc/releases"
     },
     {
       "name": "SRPC",
       "project_url": "https://github.com/sogou/srpc",
       "repository": "https://github.com/sogou/srpc",
       "compatibility_matrix_url": "https://github.com/sogou/srpc#readme",
-      "changelog_location": "https://github.com/sogou/srpc/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/sogou/srpc/releases"
     },
     {
       "name": "TARS",
       "project_url": "https://github.com/tarsCloud",
       "repository": "https://github.com/tarsCloud/tars",
       "compatibility_matrix_url": "https://github.com/TarsCloud/Tars#readme",
-      "changelog_location": "https://github.com/TarsCloud/Tars/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/TarsCloud/Tars/releases"
     },
     {
       "name": "gRPC",
       "project_url": "https://grpc.io/",
       "repository": "https://github.com/grpc/grpc",
       "compatibility_matrix_url": "https://grpc.io/docs/languages/",
-      "changelog_location": "https://github.com/grpc/grpc/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/grpc/grpc/releases"
     },
     {
       "name": "go-zero",
       "project_url": "https://go-zero.dev/",
       "repository": "https://github.com/zeromicro/go-zero",
       "compatibility_matrix_url": "https://go-zero.dev/docs/tasks",
-      "changelog_location": "https://github.com/zeromicro/go-zero/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/zeromicro/go-zero/releases"
     },
     {
       "name": "kratos",
       "project_url": "https://go-kratos.dev/",
       "repository": "https://github.com/go-kratos/kratos",
       "compatibility_matrix_url": "https://go-kratos.dev/docs/getting-started/start/",
-      "changelog_location": "https://github.com/go-kratos/kratos/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/go-kratos/kratos/releases"
     },
     {
       "name": "Apache Mesos",
       "project_url": "https://mesos.apache.org/",
       "repository": "https://github.com/apache/mesos",
       "compatibility_matrix_url": "https://mesos.apache.org/documentation/latest/",
-      "changelog_location": "https://github.com/apache/mesos/blob/master/CHANGELOG",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/apache/mesos/blob/master/CHANGELOG"
     },
     {
       "name": "Armada",
       "project_url": "https://armadaproject.io/",
       "repository": "https://github.com/armadaproject/armada",
       "compatibility_matrix_url": "https://armadaproject.io/docs",
-      "changelog_location": "https://github.com/armadaproject/armada/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/armadaproject/armada/releases"
     },
     {
       "name": "Azure Service Fabric",
       "project_url": "https://docs.microsoft.com/en-us/azure/service-fabric/",
       "repository": "https://github.com/Microsoft/service-fabric",
       "compatibility_matrix_url": "https://learn.microsoft.com/en-us/azure/service-fabric/service-fabric-versions",
-      "changelog_location": "https://github.com/Microsoft/service-fabric/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/Microsoft/service-fabric/releases"
     },
     {
       "name": "Backend.AI",
       "project_url": "https://backend.ai/",
       "repository": "https://github.com/lablup/backend.ai",
       "compatibility_matrix_url": "https://docs.backend.ai/en/latest/install/requirements.html",
-      "changelog_location": "https://github.com/lablup/backend.ai/blob/main/CHANGELOG.md",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/lablup/backend.ai/blob/main/CHANGELOG.md"
     },
     {
       "name": "Capsule",
       "project_url": "https://capsule.clastix.io",
       "repository": "https://github.com/projectcapsule/capsule",
       "compatibility_matrix_url": "https://capsule.clastix.io/docs/general/references/compatibility-matrix",
-      "changelog_location": "https://github.com/projectcapsule/capsule/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/projectcapsule/capsule/releases"
     },
     {
       "name": "Clusternet",
       "project_url": "https://clusternet.io",
       "repository": "https://github.com/clusternet/clusternet",
       "compatibility_matrix_url": "https://clusternet.io/docs/introduction/#kubernetes-version-skew",
-      "changelog_location": "https://github.com/clusternet/clusternet/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/clusternet/clusternet/releases"
     },
     {
       "name": "Clusterpedia",
       "project_url": "https://clusterpedia.io",
       "repository": "https://github.com/clusterpedia-io/clusterpedia",
       "compatibility_matrix_url": "https://clusterpedia.io/docs/getting-started/requirements/",
-      "changelog_location": "https://github.com/clusterpedia-io/clusterpedia/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/clusterpedia-io/clusterpedia/releases"
     },
     {
       "name": "CoHDI",
       "project_url": "https://github.com/CoHDI",
       "repository": "https://github.com/CoHDI",
       "compatibility_matrix_url": "https://github.com/CoHDI/composable-resource-operator",
-      "changelog_location": "https://github.com/CoHDI",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/CoHDI"
     },
     {
       "name": "Crossplane",
       "project_url": "https://crossplane.io/",
       "repository": "https://github.com/crossplane/crossplane",
       "compatibility_matrix_url": "https://docs.crossplane.io/latest/software/install/#supported-kubernetes-versions",
-      "changelog_location": "https://github.com/crossplane/crossplane/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/crossplane/crossplane/releases"
     },
     {
       "name": "DolphinScheduler",
       "project_url": "https://dolphinscheduler.apache.org",
       "repository": "https://github.com/apache/dolphinscheduler",
       "compatibility_matrix_url": "https://dolphinscheduler.apache.org/en-us/docs/latest/user_doc/guide/installation/kubernetes.html",
-      "changelog_location": "https://github.com/apache/dolphinscheduler/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/apache/dolphinscheduler/releases"
     },
     {
       "name": "Eraser",
       "project_url": "https://eraser-dev.github.io/eraser/",
       "repository": "https://github.com/eraser-dev/eraser",
       "compatibility_matrix_url": "https://eraser-dev.github.io/eraser/docs/installation/#prerequisites",
-      "changelog_location": "https://github.com/eraser-dev/eraser/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/eraser-dev/eraser/releases"
     },
     {
       "name": "Fluid",
       "project_url": "https://fluid-cloudnative.github.io/",
       "repository": "https://github.com/fluid-cloudnative/fluid",
       "compatibility_matrix_url": "https://github.com/fluid-cloudnative/fluid/blob/master/docs/en/userguide/prerequisites.md",
-      "changelog_location": "https://github.com/fluid-cloudnative/fluid/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/fluid-cloudnative/fluid/releases"
     },
     {
       "name": "Godel-Scheduler",
       "project_url": "https://github.com/kubewharf/godel-scheduler",
       "repository": "https://github.com/kubewharf/godel-scheduler",
       "compatibility_matrix_url": "https://github.com/kubewharf/godel-scheduler#prerequisites",
-      "changelog_location": "https://github.com/kubewharf/godel-scheduler/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubewharf/godel-scheduler/releases"
     },
     {
       "name": "KEDA",
       "project_url": "https://keda.sh/",
       "repository": "https://github.com/kedacore/keda",
       "compatibility_matrix_url": "https://keda.sh/docs/latest/operate/cluster/#kubernetes-compatibility",
-      "changelog_location": "https://github.com/kedacore/keda/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kedacore/keda/releases"
     },
     {
       "name": "Karmada",
       "project_url": "https://karmada.io/",
       "repository": "https://github.com/karmada-io/karmada",
       "compatibility_matrix_url": "https://karmada.io/docs/installation/#prerequisites",
-      "changelog_location": "https://github.com/karmada-io/karmada/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/karmada-io/karmada/releases"
     },
     {
       "name": "Katalyst",
       "project_url": "https://gokatalyst.io",
       "repository": "https://github.com/kubewharf/katalyst-core",
       "compatibility_matrix_url": "https://github.com/kubewharf/katalyst-core#prerequisites",
-      "changelog_location": "https://github.com/kubewharf/katalyst-core/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubewharf/katalyst-core/releases"
     },
     {
       "name": "Kestra",
       "project_url": "https://kestra.io/",
       "repository": "https://github.com/kestra-io/kestra",
       "compatibility_matrix_url": "https://kestra.io/docs/getting-started/installation",
-      "changelog_location": "https://github.com/kestra-io/kestra/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kestra-io/kestra/releases"
     },
     {
       "name": "Knative",
       "project_url": "https://knative.dev",
       "repository": "https://github.com/knative/serving",
       "compatibility_matrix_url": "https://knative.dev/docs/install/yaml-install/serving/install-serving-with-yaml/#prerequisites",
-      "changelog_location": "https://github.com/knative/serving/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/knative/serving/releases"
     },
     {
       "name": "Koordinator",
       "project_url": "https://koordinator.sh",
       "repository": "https://github.com/koordinator-sh/koordinator",
       "compatibility_matrix_url": "https://koordinator.sh/docs/installation/#prerequisites",
-      "changelog_location": "https://github.com/koordinator-sh/koordinator/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/koordinator-sh/koordinator/releases"
     },
     {
       "name": "KubeAdmiral",
       "project_url": "https://github.com/kubewharf/kubeadmiral",
       "repository": "https://github.com/kubewharf/kubeadmiral",
       "compatibility_matrix_url": "https://github.com/kubewharf/kubeadmiral#prerequisites",
-      "changelog_location": "https://github.com/kubewharf/kubeadmiral/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubewharf/kubeadmiral/releases"
     },
     {
       "name": "KubeFleet",
       "project_url": "https://kubefleet.dev/",
       "repository": "https://github.com/kubefleet-dev/kubefleet",
       "compatibility_matrix_url": "https://github.com/kubefleet-dev/kubefleet#prerequisites",
-      "changelog_location": "https://github.com/kubefleet-dev/kubefleet/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubefleet-dev/kubefleet/releases"
     },
     {
       "name": "KubeSlice",
       "project_url": "https://kubeslice.io",
       "repository": "https://github.com/kubeslice/kubeslice",
       "compatibility_matrix_url": "https://kubeslice.io/documentation/open-source/release-notes/prerequisites",
-      "changelog_location": "https://github.com/kubeslice/kubeslice/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubeslice/kubeslice/releases"
     },
     {
       "name": "KubeStellar",
       "project_url": "https://kubestellar.io",
       "repository": "https://github.com/kubestellar/kubestellar",
       "compatibility_matrix_url": "https://docs.kubestellar.io/stable/direct/pre-reqs/",
-      "changelog_location": "https://github.com/kubestellar/kubestellar/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubestellar/kubestellar/releases"
     },
     {
       "name": "Kubeflow",
       "project_url": "https://kubeflow.org",
       "repository": "https://github.com/kubeflow/kubeflow",
       "compatibility_matrix_url": "https://www.kubeflow.org/docs/releases/supported-versions/",
-      "changelog_location": "https://github.com/kubeflow/kubeflow/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubeflow/kubeflow/releases"
     },
     {
       "name": "Kubernetes",
       "project_url": "https://kubernetes.io/",
       "repository": "https://github.com/kubernetes/kubernetes",
       "compatibility_matrix_url": "https://kubernetes.io/releases/version-skew-policy/",
-      "changelog_location": "https://github.com/kubernetes/kubernetes/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubernetes/kubernetes/releases"
     },
     {
       "name": "Kured",
       "project_url": "https://kured.dev",
       "repository": "https://github.com/kubereboot/kured",
       "compatibility_matrix_url": "https://kured.dev/docs/installation/#kubernetes-compatibility",
-      "changelog_location": "https://github.com/kubereboot/kured/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubereboot/kured/releases"
     },
     {
       "name": "Nomad",
       "project_url": "https://www.nomadproject.io/",
       "repository": "https://github.com/hashicorp/nomad",
       "compatibility_matrix_url": "https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific",
-      "changelog_location": "https://github.com/hashicorp/nomad/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/hashicorp/nomad/releases"
     },
     {
       "name": "Open Cluster Management",
       "project_url": "https://open-cluster-management.io/",
       "repository": "https://github.com/open-cluster-management-io/ocm",
       "compatibility_matrix_url": "https://open-cluster-management.io/community/releases/",
-      "changelog_location": "https://github.com/open-cluster-management-io/ocm/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/open-cluster-management-io/ocm/releases"
     },
     {
       "name": "OpenFunction",
       "project_url": "https://openfunction.dev",
       "repository": "https://github.com/OpenFunction/OpenFunction",
       "compatibility_matrix_url": "https://openfunction.dev/docs/getting-started/installation/#prerequisites",
-      "changelog_location": "https://github.com/OpenFunction/OpenFunction/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/OpenFunction/OpenFunction/releases"
     },
     {
       "name": "OpenNebula",
       "project_url": "https://opennebula.io/",
       "repository": "https://github.com/OpenNebula/one",
       "compatibility_matrix_url": "https://docs.opennebula.io/stable/intro_release_notes/release_notes/platform_notes.html",
-      "changelog_location": "https://github.com/OpenNebula/one/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/OpenNebula/one/releases"
     },
     {
       "name": "Prefect",
       "project_url": "https://docs.prefect.io/",
       "repository": "https://github.com/PrefectHQ/prefect",
       "compatibility_matrix_url": "https://docs.prefect.io/latest/getting-started/installation/",
-      "changelog_location": "https://github.com/PrefectHQ/prefect/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/PrefectHQ/prefect/releases"
     },
     {
       "name": "Serverless Devs",
       "project_url": "https://www.serverless-devs.com/",
       "repository": "https://github.com/serverless-devs/serverless-devs",
       "compatibility_matrix_url": "https://github.com/serverless-devs/serverless-devs#prerequisites",
-      "changelog_location": "https://github.com/serverless-devs/serverless-devs/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/serverless-devs/serverless-devs/releases"
     },
     {
       "name": "Slurm",
       "project_url": "https://slurm.schedmd.com/",
       "repository": "https://github.com/SchedMD/slurm",
       "compatibility_matrix_url": "https://slurm.schedmd.com/quickstart_admin.html#prereqs",
-      "changelog_location": "https://github.com/SchedMD/slurm/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/SchedMD/slurm/releases"
     },
     {
       "name": "StackStorm",
       "project_url": "https://stackstorm.com/",
       "repository": "https://github.com/stackstorm/st2",
       "compatibility_matrix_url": "https://docs.stackstorm.com/install/system_requirements.html",
-      "changelog_location": "https://github.com/StackStorm/st2/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/StackStorm/st2/releases"
     },
     {
       "name": "Volcano",
       "project_url": "https://volcano.sh/",
       "repository": "https://github.com/volcano-sh/volcano",
       "compatibility_matrix_url": "https://volcano.sh/en/docs/installation/#prerequisites",
-      "changelog_location": "https://github.com/volcano-sh/volcano/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/volcano-sh/volcano/releases"
     },
     {
       "name": "hami",
       "project_url": "https://project-hami.github.io/HAMi/",
       "repository": "https://github.com/Project-HAMi/HAMi",
       "compatibility_matrix_url": "https://github.com/Project-HAMi/HAMi/blob/master/README.md#prerequisites",
-      "changelog_location": "https://github.com/Project-HAMi/HAMi/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/Project-HAMi/HAMi/releases"
     },
     {
       "name": "k0rdent",
       "project_url": "https://k0rdent.io/",
       "repository": "https://github.com/k0rdent/k0rdent",
       "compatibility_matrix_url": "https://github.com/k0rdent/k0rdent/blob/main/README.md",
-      "changelog_location": "https://github.com/k0rdent/k0rdent/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/k0rdent/k0rdent/releases"
     },
     {
       "name": "k0s",
       "project_url": "https://k0sproject.io/",
       "repository": "https://github.com/k0sproject/k0s",
       "compatibility_matrix_url": "https://docs.k0sproject.io/stable/system-requirements/",
-      "changelog_location": "https://github.com/k0sproject/k0s/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/k0sproject/k0s/releases"
     },
     {
       "name": "kcp",
       "project_url": "https://kcp.io",
       "repository": "https://github.com/kcp-dev/kcp",
       "compatibility_matrix_url": "https://docs.kcp.io/kcp/main/",
-      "changelog_location": "https://github.com/kcp-dev/kcp/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kcp-dev/kcp/releases"
     },
     {
       "name": "kube-green",
       "project_url": "https://kube-green.dev/",
       "repository": "https://github.com/kube-green/kube-green",
       "compatibility_matrix_url": "https://kube-green.dev/docs/getting-started/#prerequisites",
-      "changelog_location": "https://github.com/kube-green/kube-green/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kube-green/kube-green/releases"
     },
     {
       "name": "kube-rs",
       "project_url": "https://kube.rs",
       "repository": "https://github.com/kube-rs/kube",
       "compatibility_matrix_url": "https://kube.rs/kubernetes-version/",
-      "changelog_location": "https://github.com/kube-rs/kube/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kube-rs/kube/releases"
     },
     {
       "name": "wasmCloud",
       "project_url": "https://wasmcloud.com",
       "repository": "https://github.com/wasmCloud/wasmCloud",
       "compatibility_matrix_url": "https://wasmcloud.com/docs/installation",
-      "changelog_location": "https://github.com/wasmCloud/wasmCloud/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/wasmCloud/wasmCloud/releases"
     },
     {
       "name": "Aeraki Mesh",
       "project_url": "https://www.aeraki.net/",
       "repository": "https://github.com/aeraki-mesh/aeraki",
       "compatibility_matrix_url": "https://aeraki.net/docs/v1.x/install/#prerequisites",
-      "changelog_location": "https://github.com/aeraki-mesh/aeraki/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/aeraki-mesh/aeraki/releases"
     },
     {
       "name": "Consul",
       "project_url": "https://www.consul.io/",
       "repository": "https://github.com/hashicorp/consul",
       "compatibility_matrix_url": "https://developer.hashicorp.com/consul/docs/upgrade/k8s/compatibility",
-      "changelog_location": "https://github.com/hashicorp/consul/blob/main/CHANGELOG.md",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/hashicorp/consul/blob/main/CHANGELOG.md"
     },
     {
       "name": "EaseMesh",
       "project_url": "https://megaease.com/easemesh",
       "repository": "https://github.com/megaease/easemesh",
       "compatibility_matrix_url": "https://github.com/megaease/easemesh/blob/main/README.md",
-      "changelog_location": "https://github.com/megaease/easemesh/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/megaease/easemesh/releases"
     },
     {
       "name": "Flomesh Service Mesh (FSM)",
       "project_url": "https://flomesh.io/",
       "repository": "https://github.com/flomesh-io/fsm",
       "compatibility_matrix_url": "https://fsm-docs.flomesh.io/docs/getting_started/prerequisites/",
-      "changelog_location": "https://github.com/flomesh-io/fsm/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/flomesh-io/fsm/releases"
     },
     {
       "name": "Istio",
       "project_url": "https://istio.io/",
       "repository": "https://github.com/istio/istio",
       "compatibility_matrix_url": "https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases",
-      "changelog_location": "https://github.com/istio/istio/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/istio/istio/releases"
     },
     {
       "name": "Kmesh",
       "project_url": "https://kmesh.net",
       "repository": "https://github.com/kmesh-net/kmesh",
       "compatibility_matrix_url": "https://kmesh.net/en/docs/setup/prerequisites/",
-      "changelog_location": "https://github.com/kmesh-net/kmesh/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kmesh-net/kmesh/releases"
     },
     {
       "name": "Kuma",
       "project_url": "https://kuma.io",
       "repository": "https://github.com/kumahq/kuma",
       "compatibility_matrix_url": "https://kuma.io/docs/latest/introduction/version-matrix/",
-      "changelog_location": "https://github.com/kumahq/kuma/blob/master/CHANGELOG.md",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kumahq/kuma/blob/master/CHANGELOG.md"
     },
     {
       "name": "Linkerd",
       "project_url": "https://linkerd.io/",
       "repository": "https://github.com/linkerd/linkerd2",
       "compatibility_matrix_url": "https://linkerd.io/2-edge/reference/k8s-versions/",
-      "changelog_location": "https://github.com/linkerd/linkerd2/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/linkerd/linkerd2/releases"
     },
     {
       "name": "Merbridge",
       "project_url": "https://merbridge.io/",
       "repository": "https://github.com/merbridge/merbridge",
       "compatibility_matrix_url": "https://github.com/merbridge/merbridge/blob/main/README.md",
-      "changelog_location": "https://github.com/merbridge/merbridge/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/merbridge/merbridge/releases"
     },
     {
       "name": "Open Service Mesh",
       "project_url": "https://openservicemesh.io/",
       "repository": "https://github.com/openservicemesh/osm",
       "compatibility_matrix_url": "https://release-v1-2.docs.openservicemesh.io/docs/getting_started/setup_osm/#prerequisites",
-      "changelog_location": "https://github.com/openservicemesh/osm/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/openservicemesh/osm/releases"
     },
     {
       "name": "OpenSergo",
       "project_url": "https://opensergo.io/",
       "repository": "https://github.com/opensergo/opensergo-specification",
       "compatibility_matrix_url": "https://opensergo.io/docs/what-is-opensergo/intro/",
-      "changelog_location": "https://github.com/opensergo/opensergo-specification/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/opensergo/opensergo-specification/releases"
     },
     {
       "name": "Sermant",
       "project_url": "https://sermant.io/",
       "repository": "https://github.com/sermant-io/Sermant",
       "compatibility_matrix_url": "https://sermant.io/en/document/user-guide/version-compatibility.html",
-      "changelog_location": "https://github.com/sermant-io/Sermant/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/sermant-io/Sermant/releases"
     },
     {
       "name": "Service Mesh Interface (SMI)",
       "project_url": "https://smi-spec.io",
       "repository": "https://github.com/servicemeshinterface/smi-spec",
       "compatibility_matrix_url": "https://smi-spec.io/",
-      "changelog_location": "https://github.com/servicemeshinterface/smi-spec/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/servicemeshinterface/smi-spec/releases"
     },
     {
       "name": "Service Mesh Performance",
       "project_url": "https://smp-spec.io/",
       "repository": "https://github.com/service-mesh-performance/service-mesh-performance",
       "compatibility_matrix_url": "https://smp-spec.io/",
-      "changelog_location": "https://github.com/service-mesh-performance/service-mesh-performance/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/service-mesh-performance/service-mesh-performance/releases"
     },
     {
       "name": "Slime",
       "project_url": "https://github.com/slime-io",
       "repository": "https://github.com/slime-io/slime",
       "compatibility_matrix_url": "https://github.com/slime-io/slime/blob/master/README.md",
-      "changelog_location": "https://github.com/slime-io/slime/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/slime-io/slime/releases"
     },
     {
       "name": "Traefik Mesh",
       "project_url": "https://traefik.io/traefik-mesh",
       "repository": "https://github.com/traefik/mesh",
       "compatibility_matrix_url": "https://doc.traefik.io/traefik-mesh/",
-      "changelog_location": "https://github.com/traefik/mesh/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/traefik/mesh/releases"
     },
     {
       "name": "BFE",
       "project_url": "https://www.bfe-networks.net",
       "repository": "https://github.com/bfenetworks/bfe",
       "compatibility_matrix_url": "https://github.com/bfenetworks/bfe/blob/develop/README.md",
-      "changelog_location": "https://github.com/bfenetworks/bfe/blob/develop/CHANGELOG.md",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/bfenetworks/bfe/blob/develop/CHANGELOG.md"
     },
     {
       "name": "Caddy",
       "project_url": "https://caddyserver.com/",
       "repository": "https://github.com/caddyserver/caddy",
       "compatibility_matrix_url": "https://github.com/caddyserver/caddy/blob/master/README.md",
-      "changelog_location": "https://github.com/caddyserver/caddy/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/caddyserver/caddy/releases"
     },
     {
       "name": "Contour",
       "project_url": "https://projectcontour.io",
       "repository": "https://github.com/projectcontour/contour",
       "compatibility_matrix_url": "https://projectcontour.io/resources/compatibility-matrix/",
-      "changelog_location": "https://github.com/projectcontour/contour/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/projectcontour/contour/releases"
     },
     {
       "name": "Envoy",
       "project_url": "https://www.envoyproxy.io",
       "repository": "https://github.com/envoyproxy/envoy",
       "compatibility_matrix_url": "https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history",
-      "changelog_location": "https://github.com/envoyproxy/envoy/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/envoyproxy/envoy/releases"
     },
     {
       "name": "HAProxy",
       "project_url": "https://www.haproxy.com/",
       "repository": "https://github.com/haproxy/haproxy",
       "compatibility_matrix_url": "https://github.com/haproxy/haproxy/blob/master/README.md",
-      "changelog_location": "https://github.com/haproxy/haproxy/blob/master/CHANGELOG",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/haproxy/haproxy/blob/master/CHANGELOG"
     },
     {
       "name": "Inlets",
       "project_url": "https://docs.inlets.dev",
       "repository": "https://github.com/inlets/inlets-pro",
       "compatibility_matrix_url": "https://docs.inlets.dev/reference/faq/",
-      "changelog_location": "https://github.com/inlets/inlets-pro/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/inlets/inlets-pro/releases"
     },
     {
       "name": "LoxiLB",
       "project_url": "https://loxilb.io",
       "repository": "https://github.com/loxilb-io/loxilb",
       "compatibility_matrix_url": "https://docs.loxilb.io/latest/kube-loxilb/#supported-kubernetes-versions",
-      "changelog_location": "https://github.com/loxilb-io/loxilb/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/loxilb-io/loxilb/releases"
     },
     {
       "name": "MOSN",
       "project_url": "https://mosn.io",
       "repository": "https://github.com/mosn/mosn",
       "compatibility_matrix_url": "https://mosn.io/docs/products/overview/",
-      "changelog_location": "https://github.com/mosn/mosn/blob/master/CHANGELOG.md",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/mosn/mosn/blob/master/CHANGELOG.md"
     },
     {
       "name": "MetalLB",
       "project_url": "https://metallb.universe.tf",
       "repository": "https://github.com/metallb/metallb",
       "compatibility_matrix_url": "https://metallb.io/installation/#requirements",
-      "changelog_location": "https://github.com/metallb/metallb/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/metallb/metallb/releases"
     },
     {
       "name": "NGINX",
       "project_url": "https://www.nginx.com/",
       "repository": "https://github.com/nginx/nginx",
       "compatibility_matrix_url": "https://docs.nginx.com/nginx/releases/",
-      "changelog_location": "https://nginx.org/en/CHANGES",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://nginx.org/en/CHANGES"
     },
     {
       "name": "Netflix Zuul",
       "project_url": "https://github.com/Netflix/zuul",
       "repository": "https://github.com/Netflix/zuul",
       "compatibility_matrix_url": "https://github.com/Netflix/zuul/wiki",
-      "changelog_location": "https://github.com/Netflix/zuul/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/Netflix/zuul/releases"
     },
     {
       "name": "OpenELB",
       "project_url": "https://openelb.github.io",
       "repository": "https://github.com/openelb/openelb",
       "compatibility_matrix_url": "https://openelb.io/docs/getting-started/prerequisites/",
-      "changelog_location": "https://github.com/openelb/openelb/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/openelb/openelb/releases"
     },
     {
       "name": "OpenResty",
       "project_url": "https://openresty.com/en/",
       "repository": "https://github.com/openresty/openresty",
       "compatibility_matrix_url": "https://openresty.org/en/changelog.html",
-      "changelog_location": "https://openresty.org/en/changelog.html",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://openresty.org/en/changelog.html"
     },
     {
       "name": "Pipy",
       "project_url": "https://flomesh.io/pipy/",
       "repository": "https://github.com/flomesh-io/pipy",
       "compatibility_matrix_url": "https://flomesh.io/docs/",
-      "changelog_location": "https://github.com/flomesh-io/pipy/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/flomesh-io/pipy/releases"
     },
     {
       "name": "STUNner",
       "project_url": "https://l7mp.io",
       "repository": "https://github.com/l7mp/stunner",
       "compatibility_matrix_url": "https://github.com/l7mp/stunner/blob/main/README.md",
-      "changelog_location": "https://github.com/l7mp/stunner/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/l7mp/stunner/releases"
     },
     {
       "name": "Sentinel",
       "project_url": "https://sentinelguard.io/en-us/",
       "repository": "https://github.com/alibaba/Sentinel",
       "compatibility_matrix_url": "https://sentinelguard.io/en-us/docs/introduction.html",
-      "changelog_location": "https://github.com/alibaba/Sentinel/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/alibaba/Sentinel/releases"
     },
     {
       "name": "Skipper",
       "project_url": "https://opensource.zalando.com/skipper/",
       "repository": "https://github.com/zalando/skipper",
       "compatibility_matrix_url": "https://opensource.zalando.com/skipper/kubernetes/ingress-usage/",
-      "changelog_location": "https://github.com/zalando/skipper/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/zalando/skipper/releases"
     },
     {
       "name": "Tengine",
       "project_url": "https://tengine.taobao.org/",
       "repository": "https://github.com/alibaba/tengine",
       "compatibility_matrix_url": "https://tengine.taobao.org/documentation.html",
-      "changelog_location": "https://github.com/alibaba/tengine/blob/master/CHANGES",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/alibaba/tengine/blob/master/CHANGES"
     },
     {
       "name": "Temporal",
       "project_url": "https://temporal.io/",
       "repository": "https://github.com/temporalio/temporal",
       "compatibility_matrix_url": "https://github.com/temporalio/helm-charts#readme",
-      "changelog_location": "https://github.com/temporalio/temporal/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/temporalio/temporal/releases"
     },
     {
       "name": "Score",
       "project_url": "https://score.dev/",
       "repository": "https://github.com/score-spec/spec",
       "compatibility_matrix_url": "https://docs.score.dev/docs/get-started/",
-      "changelog_location": "https://github.com/score-spec/spec/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/score-spec/spec/releases"
     },
     {
       "name": "Carvel (kapp)",
       "project_url": "https://carvel.dev/",
       "repository": "https://github.com/carvel-dev/kapp",
       "compatibility_matrix_url": "https://carvel.dev/kapp/docs/latest/install/",
-      "changelog_location": "https://github.com/carvel-dev/kapp/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/carvel-dev/kapp/releases"
     },
     {
       "name": "kpt",
       "project_url": "https://kpt.dev/",
       "repository": "https://github.com/kptdev/kpt",
       "compatibility_matrix_url": "https://kpt.dev/installation/",
-      "changelog_location": "https://github.com/kptdev/kpt/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/kptdev/kpt/releases"
     },
     {
       "name": "ChartMuseum",
       "project_url": "https://chartmuseum.com/",
       "repository": "https://github.com/helm/chartmuseum",
       "compatibility_matrix_url": "https://chartmuseum.com/docs/#installation",
-      "changelog_location": "https://github.com/helm/chartmuseum/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/helm/chartmuseum/releases"
     },
     {
       "name": "Helmfile",
       "project_url": "https://helmfile.readthedocs.io/",
       "repository": "https://github.com/helmfile/helmfile",
       "compatibility_matrix_url": "https://helmfile.readthedocs.io/en/latest/#installation",
-      "changelog_location": "https://github.com/helmfile/helmfile/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/helmfile/helmfile/releases"
     },
     {
       "name": "Timoni",
       "project_url": "https://timoni.sh/",
       "repository": "https://github.com/stefanprodan/timoni",
       "compatibility_matrix_url": "https://timoni.sh/install/",
-      "changelog_location": "https://github.com/stefanprodan/timoni/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/stefanprodan/timoni/releases"
     },
     {
       "name": "kapp-controller",
       "project_url": "https://carvel.dev/kapp-controller/",
       "repository": "https://github.com/carvel-dev/kapp-controller",
       "compatibility_matrix_url": "https://carvel.dev/kapp-controller/docs/latest/install/",
-      "changelog_location": "https://github.com/carvel-dev/kapp-controller/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/carvel-dev/kapp-controller/releases"
     },
     {
       "name": "Vertical Pod Autoscaler",
       "project_url": "https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler",
       "repository": "https://github.com/kubernetes/autoscaler",
       "compatibility_matrix_url": "https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler#prerequisites",
-      "changelog_location": "https://github.com/kubernetes/autoscaler/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubernetes/autoscaler/releases"
     },
     {
       "name": "Node Feature Discovery",
       "project_url": "https://kubernetes-sigs.github.io/node-feature-discovery/",
       "repository": "https://github.com/kubernetes-sigs/node-feature-discovery",
       "compatibility_matrix_url": "https://kubernetes-sigs.github.io/node-feature-discovery/stable/reference/versions.html",
-      "changelog_location": "https://github.com/kubernetes-sigs/node-feature-discovery/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubernetes-sigs/node-feature-discovery/releases"
     },
     {
       "name": "PodDisruptionBudget",
       "project_url": "https://kubernetes.io/docs/concepts/workloads/pods/disruptions/",
       "repository": "https://github.com/kubernetes/kubernetes",
       "compatibility_matrix_url": "https://kubernetes.io/docs/concepts/workloads/pods/disruptions/",
-      "changelog_location": "https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/README.md",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/README.md"
     },
     {
       "name": "Radius",
       "project_url": "https://radapp.io/",
       "repository": "https://github.com/radius-project/radius",
       "compatibility_matrix_url": "https://docs.radapp.io/guides/operations/kubernetes/overview/",
-      "changelog_location": "https://github.com/radius-project/radius/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/radius-project/radius/releases"
     },
     {
       "name": "Backstage",
       "project_url": "https://backstage.io/",
       "repository": "https://github.com/backstage/backstage",
       "compatibility_matrix_url": "https://backstage.io/docs/getting-started/",
-      "changelog_location": "https://github.com/backstage/backstage/releases",
-      "upgrade_path_type": "NPM-package"
+      "changelog_location": "https://github.com/backstage/backstage/releases"
     },
     {
       "name": "Pod Security Standards / Pod Security Admission",
       "project_url": "https://kubernetes.io/docs/concepts/security/pod-security-standards/",
       "repository": "https://github.com/kubernetes/kubernetes",
       "compatibility_matrix_url": "https://kubernetes.io/docs/concepts/security/pod-security-admission/",
-      "changelog_location": "https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/README.md",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/README.md"
     },
     {
       "name": "OPA Gatekeeper",
       "project_url": "https://open-policy-agent.github.io/gatekeeper/website/",
       "repository": "https://github.com/open-policy-agent/gatekeeper",
       "compatibility_matrix_url": "https://github.com/open-policy-agent/gatekeeper/blob/master/docs/Release_Management.md",
-      "changelog_location": "https://github.com/open-policy-agent/gatekeeper/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/open-policy-agent/gatekeeper/releases"
     },
     {
       "name": "Sealed Secrets",
       "project_url": "https://github.com/bitnami-labs/sealed-secrets",
       "repository": "https://github.com/bitnami-labs/sealed-secrets",
       "compatibility_matrix_url": "https://github.com/bitnami-labs/sealed-secrets#kubernetes-version",
-      "changelog_location": "https://github.com/bitnami-labs/sealed-secrets/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/bitnami-labs/sealed-secrets/releases"
     },
     {
       "name": "Vault Secrets Operator",
       "project_url": "https://developer.hashicorp.com/vault/docs/platform/k8s/vso",
       "repository": "https://github.com/hashicorp/vault-secrets-operator",
       "compatibility_matrix_url": "https://developer.hashicorp.com/vault/docs/platform/k8s/vso#supported-kubernetes-versions",
-      "changelog_location": "https://github.com/hashicorp/vault-secrets-operator/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/hashicorp/vault-secrets-operator/releases"
     },
     {
       "name": "APIClarity",
       "project_url": "https://openclarity.io/",
       "repository": "https://github.com/openclarity/apiclarity",
       "compatibility_matrix_url": "https://github.com/openclarity/apiclarity#prerequisites",
-      "changelog_location": "https://github.com/openclarity/apiclarity/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/openclarity/apiclarity/releases"
     },
     {
       "name": "Aserto",
       "project_url": "https://www.aserto.com",
       "repository": "https://github.com/aserto-dev/runtime",
       "compatibility_matrix_url": "https://github.com/aserto-dev/runtime/blob/main/README.md",
-      "changelog_location": "https://github.com/aserto-dev/runtime/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/aserto-dev/runtime/releases"
     },
     {
       "name": "Bank-Vaults",
       "project_url": "https://bank-vaults.dev/",
       "repository": "https://github.com/bank-vaults/bank-vaults",
       "compatibility_matrix_url": "https://bank-vaults.dev/docs/installing/",
-      "changelog_location": "https://github.com/bank-vaults/bank-vaults/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/bank-vaults/bank-vaults/releases"
     },
     {
       "name": "Bouncy Castle",
       "project_url": "https://www.bouncycastle.org/",
       "repository": "https://github.com/bcgit/bc-java",
       "compatibility_matrix_url": "https://www.bouncycastle.org/latest_releases.html",
-      "changelog_location": "https://github.com/bcgit/bc-java/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/bcgit/bc-java/releases"
     },
     {
       "name": "Boundary",
       "project_url": "https://www.boundaryproject.io/",
       "repository": "https://github.com/hashicorp/boundary",
       "compatibility_matrix_url": "https://developer.hashicorp.com/boundary/docs/release-notes",
-      "changelog_location": "https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/hashicorp/boundary/blob/main/CHANGELOG.md"
     },
     {
       "name": "Cartography",
       "project_url": "https://cartography.dev",
       "repository": "https://github.com/cartography-cncf/cartography",
       "compatibility_matrix_url": "https://cartography-cncf.github.io/cartography/install.html",
-      "changelog_location": "https://github.com/cartography-cncf/cartography/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/cartography-cncf/cartography/releases"
     },
     {
       "name": "Cedar",
       "project_url": "https://cedarpolicy.com",
       "repository": "https://github.com/cedar-policy/cedar",
       "compatibility_matrix_url": "https://github.com/cedar-policy/cedar/blob/main/README.md",
-      "changelog_location": "https://github.com/cedar-policy/cedar/blob/main/CHANGELOG.md",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/cedar-policy/cedar/blob/main/CHANGELOG.md"
     },
     {
       "name": "Cerbos",
       "project_url": "https://www.cerbos.dev/",
       "repository": "https://github.com/cerbos/cerbos",
       "compatibility_matrix_url": "https://docs.cerbos.dev/cerbos/latest/installation/",
-      "changelog_location": "https://github.com/cerbos/cerbos/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/cerbos/cerbos/releases"
     },
     {
       "name": "Checkov",
       "project_url": "https://www.checkov.io/",
       "repository": "https://github.com/bridgecrewio/checkov",
       "compatibility_matrix_url": "https://www.checkov.io/1.Welcome/Quick%20Start.html",
-      "changelog_location": "https://github.com/bridgecrewio/checkov/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/bridgecrewio/checkov/releases"
     },
     {
       "name": "Chef InSpec",
       "project_url": "https://community.chef.io/tools/chef-inspec",
       "repository": "https://github.com/inspec/inspec",
       "compatibility_matrix_url": "https://docs.chef.io/inspec/platforms/",
-      "changelog_location": "https://github.com/inspec/inspec/blob/main/CHANGELOG.md",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/inspec/inspec/blob/main/CHANGELOG.md"
     },
     {
       "name": "Clair",
       "project_url": "https://www.redhat.com/en/topics/containers/what-is-clair",
       "repository": "https://github.com/quay/clair",
       "compatibility_matrix_url": "https://quay.github.io/clair/whatis.html",
-      "changelog_location": "https://github.com/quay/clair/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/quay/clair/releases"
     },
     {
       "name": "CloudMatos",
       "project_url": "https://www.cloudmatos.com",
       "repository": "https://github.com/cloudmatos/matos",
       "compatibility_matrix_url": "https://github.com/cloudmatos/matos/blob/main/README.md",
-      "changelog_location": "https://github.com/cloudmatos/matos/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/cloudmatos/matos/releases"
     },
     {
       "name": "Confidential Containers",
       "project_url": "https://confidentialcontainers.org/",
       "repository": "https://github.com/confidential-containers/confidential-containers",
       "compatibility_matrix_url": "https://github.com/confidential-containers/confidential-containers/blob/main/releases/SUPPORTED_RELEASES.md",
-      "changelog_location": "https://github.com/confidential-containers/confidential-containers/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/confidential-containers/confidential-containers/releases"
     },
     {
       "name": "ContainerSSH",
       "project_url": "https://containerssh.io",
       "repository": "https://github.com/containerssh/containerssh",
       "compatibility_matrix_url": "https://containerssh.io/reference/installation/",
-      "changelog_location": "https://github.com/containerssh/containerssh/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/containerssh/containerssh/releases"
     },
     {
       "name": "Copa",
       "project_url": "https://github.com/project-copacetic/copacetic",
       "repository": "https://github.com/project-copacetic/copacetic",
       "compatibility_matrix_url": "https://project-copacetic.github.io/copacetic/website/installation",
-      "changelog_location": "https://github.com/project-copacetic/copacetic/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/project-copacetic/copacetic/releases"
     },
     {
       "name": "Dex",
       "project_url": "https://dexidp.io/",
       "repository": "https://github.com/dexidp/dex",
       "compatibility_matrix_url": "https://dexidp.io/docs/getting-started/",
-      "changelog_location": "https://github.com/dexidp/dex/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/dexidp/dex/releases"
     },
     {
       "name": "EJBCA Community",
       "project_url": "https://www.ejbca.org/",
       "repository": "https://github.com/Keyfactor/ejbca-ce",
       "compatibility_matrix_url": "https://doc.primekey.com/ejbca/ejbca-release-information/ejbca-platform-support-matrix",
-      "changelog_location": "https://github.com/Keyfactor/ejbca-ce/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/Keyfactor/ejbca-ce/releases"
     },
     {
       "name": "FOSSA",
       "project_url": "https://fossa.com/",
       "repository": "https://github.com/fossas/fossa-cli",
       "compatibility_matrix_url": "https://github.com/fossas/fossa-cli/blob/master/README.md",
-      "changelog_location": "https://github.com/fossas/fossa-cli/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/fossas/fossa-cli/releases"
     },
     {
       "name": "Falco",
       "project_url": "https://falco.org/",
       "repository": "https://github.com/falcosecurity/falco",
       "compatibility_matrix_url": "https://falco.org/docs/setup/kubernetes/",
-      "changelog_location": "https://github.com/falcosecurity/falco/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/falcosecurity/falco/releases"
     },
     {
       "name": "Goldilocks",
       "project_url": "https://www.fairwinds.com/open-source-software",
       "repository": "https://github.com/FairwindsOps/goldilocks",
       "compatibility_matrix_url": "https://github.com/FairwindsOps/goldilocks/blob/master/README.md",
-      "changelog_location": "https://github.com/FairwindsOps/goldilocks/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/FairwindsOps/goldilocks/releases"
     },
     {
       "name": "Grafeas",
       "project_url": "https://grafeas.io/",
       "repository": "https://github.com/grafeas/grafeas",
       "compatibility_matrix_url": "https://github.com/grafeas/grafeas/blob/master/README.md",
-      "changelog_location": "https://github.com/grafeas/grafeas/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/grafeas/grafeas/releases"
     },
     {
       "name": "Hexa",
       "project_url": "https://hexaorchestration.org/",
       "repository": "https://github.com/hexa-org/policy-orchestrator",
       "compatibility_matrix_url": "https://github.com/hexa-org/policy-orchestrator/blob/main/README.md",
-      "changelog_location": "https://github.com/hexa-org/policy-orchestrator/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/hexa-org/policy-orchestrator/releases"
     },
     {
       "name": "KICS",
       "project_url": "https://kics.io/",
       "repository": "https://github.com/Checkmarx/kics",
       "compatibility_matrix_url": "https://docs.kics.io/latest/platforms/",
-      "changelog_location": "https://github.com/Checkmarx/kics/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/Checkmarx/kics/releases"
     },
     {
       "name": "Keycloak",
       "project_url": "https://www.keycloak.org/",
       "repository": "https://github.com/keycloak/keycloak",
       "compatibility_matrix_url": "https://www.keycloak.org/operator/installation",
-      "changelog_location": "https://github.com/keycloak/keycloak/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/keycloak/keycloak/releases"
     },
     {
       "name": "Keylime",
       "project_url": "https://keylime.dev/",
       "repository": "https://github.com/keylime/keylime",
       "compatibility_matrix_url": "https://keylime.readthedocs.io/en/latest/installation.html",
-      "changelog_location": "https://github.com/keylime/keylime/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/keylime/keylime/releases"
     },
     {
       "name": "KubeArmor",
       "project_url": "https://kubearmor.io/",
       "repository": "https://github.com/kubearmor/kubearmor",
       "compatibility_matrix_url": "https://docs.kubearmor.io/kubearmor/quick-links/support_matrix",
-      "changelog_location": "https://github.com/kubearmor/KubeArmor/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubearmor/KubeArmor/releases"
     },
     {
       "name": "KubeLinter",
       "project_url": "https://docs.kubelinter.io/",
       "repository": "https://github.com/stackrox/kube-linter",
       "compatibility_matrix_url": "https://github.com/stackrox/kube-linter/blob/main/README.md",
-      "changelog_location": "https://github.com/stackrox/kube-linter/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/stackrox/kube-linter/releases"
     },
     {
       "name": "Kubescape",
       "project_url": "https://kubescape.io/",
       "repository": "https://github.com/kubescape/kubescape",
       "compatibility_matrix_url": "https://kubescape.io/docs/install-operator/",
-      "changelog_location": "https://github.com/kubescape/kubescape/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubescape/kubescape/releases"
     },
     {
       "name": "Kubewarden",
       "project_url": "https://www.kubewarden.io",
       "repository": "https://github.com/kubewarden/kubewarden-controller",
       "compatibility_matrix_url": "https://docs.kubewarden.io/reference/compatibility-matrix",
-      "changelog_location": "https://github.com/kubewarden/kubewarden-controller/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubewarden/kubewarden-controller/releases"
     },
     {
       "name": "Kyverno",
       "project_url": "https://kyverno.io/",
       "repository": "https://github.com/kyverno/kyverno",
       "compatibility_matrix_url": "https://kyverno.io/docs/installation/#compatibility-matrix",
-      "changelog_location": "https://github.com/kyverno/kyverno/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kyverno/kyverno/releases"
     },
     {
       "name": "Matano",
       "project_url": "https://www.matano.dev",
       "repository": "https://github.com/matanolabs/matano",
       "compatibility_matrix_url": "https://www.matano.dev/docs/getting-started",
-      "changelog_location": "https://github.com/matanolabs/matano/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/matanolabs/matano/releases"
     },
     {
       "name": "Metarget",
       "project_url": "https://github.com/Metarget/metarget",
       "repository": "https://github.com/Metarget/metarget",
       "compatibility_matrix_url": "https://github.com/Metarget/metarget#supported-cnis-and-kubernetes-versions",
-      "changelog_location": "https://github.com/Metarget/metarget/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/Metarget/metarget/releases"
     },
     {
       "name": "NeuVector",
       "project_url": "https://neuvector.com/",
       "repository": "https://github.com/neuvector/neuvector",
       "compatibility_matrix_url": "https://www.suse.com/suse-neuvector/support-matrix/all-supported-versions/neuvector-v-all-versions/",
-      "changelog_location": "https://github.com/neuvector/neuvector/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/neuvector/neuvector/releases"
     },
     {
       "name": "Notary Project",
       "project_url": "https://notaryproject.dev/",
       "repository": "https://github.com/notaryproject/notation",
       "compatibility_matrix_url": "https://notaryproject.dev/docs/user-guides/installation/",
-      "changelog_location": "https://github.com/notaryproject/notation/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/notaryproject/notation/releases"
     },
     {
       "name": "OAuth2 Proxy",
       "project_url": "https://oauth2-proxy.github.io/oauth2-proxy/",
       "repository": "https://github.com/oauth2-proxy/oauth2-proxy",
       "compatibility_matrix_url": "https://oauth2-proxy.github.io/oauth2-proxy/installation",
-      "changelog_location": "https://github.com/oauth2-proxy/oauth2-proxy/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/oauth2-proxy/oauth2-proxy/releases"
     },
     {
       "name": "OSCAL-COMPASS",
       "project_url": "https://github.com/oscal-compass/community",
       "repository": "https://github.com/oscal-compass/compliance-trestle",
       "compatibility_matrix_url": "https://github.com/oscal-compass/compliance-trestle#readme",
-      "changelog_location": "https://github.com/oscal-compass/compliance-trestle/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/oscal-compass/compliance-trestle/releases"
     },
     {
       "name": "Open Policy Administration Layer (OPAL)",
       "project_url": "https://www.opal.ac",
       "repository": "https://github.com/permitio/opal",
       "compatibility_matrix_url": "https://github.com/permitio/opal#readme",
-      "changelog_location": "https://github.com/permitio/opal/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/permitio/opal/releases"
     },
     {
       "name": "Open Policy Agent (OPA)",
       "project_url": "https://www.openpolicyagent.org/",
       "repository": "https://github.com/open-policy-agent/opa",
       "compatibility_matrix_url": "https://www.openpolicyagent.org/docs/latest/kubernetes-introduction/",
-      "changelog_location": "https://github.com/open-policy-agent/opa/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/open-policy-agent/opa/releases"
     },
     {
       "name": "Open Policy Containers",
       "project_url": "https://openpolicycontainers.com",
       "repository": "https://github.com/opcr-io/policy",
       "compatibility_matrix_url": "https://github.com/opcr-io/policy#readme",
-      "changelog_location": "https://github.com/opcr-io/policy/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/opcr-io/policy/releases"
     },
     {
       "name": "OpenFGA",
       "project_url": "https://openfga.dev",
       "repository": "https://github.com/openfga/openfga",
       "compatibility_matrix_url": "https://openfga.dev/docs/getting-started/setup-openfga/kubernetes",
-      "changelog_location": "https://github.com/openfga/openfga/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/openfga/openfga/releases"
     },
     {
       "name": "OpenSCAP",
       "project_url": "https://www.open-scap.org/",
       "repository": "https://github.com/OpenSCAP/openscap",
       "compatibility_matrix_url": "https://www.open-scap.org/download/",
-      "changelog_location": "https://github.com/OpenSCAP/openscap/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/OpenSCAP/openscap/releases"
     },
     {
       "name": "Paladin Cloud",
       "project_url": "https://paladincloud.io/",
       "repository": "https://github.com/PaladinCloud/CE",
       "compatibility_matrix_url": "https://github.com/PaladinCloud/CE#prerequisites",
-      "changelog_location": "https://github.com/PaladinCloud/CE/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/PaladinCloud/CE/releases"
     },
     {
       "name": "Paralus",
       "project_url": "https://www.paralus.io/",
       "repository": "https://github.com/paralus/paralus",
       "compatibility_matrix_url": "https://www.paralus.io/docs/installation/",
-      "changelog_location": "https://github.com/paralus/paralus/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/paralus/paralus/releases"
     },
     {
       "name": "Parsec",
       "project_url": "https://parsec.community/",
       "repository": "https://github.com/parallaxsecond/parsec",
       "compatibility_matrix_url": "https://parallaxsecond.github.io/parsec-book/parsec_service/install_parsec_linux.html",
-      "changelog_location": "https://github.com/parallaxsecond/parsec/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/parallaxsecond/parsec/releases"
     },
     {
       "name": "Permify",
       "project_url": "https://permify.co",
       "repository": "https://github.com/Permify/permify",
       "compatibility_matrix_url": "https://docs.permify.co/docs/installation/kubernetes",
-      "changelog_location": "https://github.com/Permify/permify/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/Permify/permify/releases"
     },
     {
       "name": "Pluto",
       "project_url": "https://www.fairwinds.com/open-source-software",
       "repository": "https://github.com/FairwindsOps/pluto",
       "compatibility_matrix_url": "https://pluto.docs.fairwinds.com/",
-      "changelog_location": "https://github.com/FairwindsOps/pluto/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/FairwindsOps/pluto/releases"
     },
     {
       "name": "Polaris",
       "project_url": "https://fairwinds.com/polaris",
       "repository": "https://github.com/FairwindsOps/polaris",
       "compatibility_matrix_url": "https://polaris.docs.fairwinds.com/infrastructure-as-code/#install-the-cli",
-      "changelog_location": "https://github.com/FairwindsOps/polaris/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/FairwindsOps/polaris/releases"
     },
     {
       "name": "Pomerium",
       "project_url": "https://www.pomerium.com/",
       "repository": "https://github.com/pomerium/pomerium",
       "compatibility_matrix_url": "https://www.pomerium.com/docs/deploy/k8s/install",
-      "changelog_location": "https://github.com/pomerium/pomerium/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/pomerium/pomerium/releases"
     },
     {
       "name": "RBAC Lookup",
       "project_url": "https://www.fairwinds.com/open-source-software",
       "repository": "https://github.com/FairwindsOps/rbac-lookup",
       "compatibility_matrix_url": "https://github.com/FairwindsOps/rbac-lookup#readme",
-      "changelog_location": "https://github.com/FairwindsOps/rbac-lookup/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/FairwindsOps/rbac-lookup/releases"
     },
     {
       "name": "RBAC Manager",
       "project_url": "https://www.fairwinds.com/open-source-software",
       "repository": "https://github.com/FairwindsOps/rbac-manager",
       "compatibility_matrix_url": "https://github.com/FairwindsOps/rbac-manager#readme",
-      "changelog_location": "https://github.com/FairwindsOps/rbac-manager/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/FairwindsOps/rbac-manager/releases"
     },
     {
       "name": "Ratify",
       "project_url": "https://ratify.dev/",
       "repository": "https://github.com/ratify-project/ratify",
       "compatibility_matrix_url": "https://ratify.dev/docs/quick-start",
-      "changelog_location": "https://github.com/ratify-project/ratify/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/ratify-project/ratify/releases"
     },
     {
       "name": "Rudder",
       "project_url": "https://www.rudder.io/",
       "repository": "https://github.com/normation/rudder",
       "compatibility_matrix_url": "https://docs.rudder.io/reference/current/installation/versions.html",
-      "changelog_location": "https://github.com/normation/rudder/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/normation/rudder/releases"
     },
     {
       "name": "SOPS",
       "project_url": "https://github.com/getsops",
       "repository": "https://github.com/getsops/sops",
       "compatibility_matrix_url": "https://github.com/getsops/sops/blob/main/README.rst",
-      "changelog_location": "https://github.com/getsops/sops/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/getsops/sops/releases"
     },
     {
       "name": "SignServer Community",
       "project_url": "https://www.signserver.org/",
       "repository": "https://github.com/Keyfactor/signserver-ce",
       "compatibility_matrix_url": "https://github.com/Keyfactor/signserver-ce#readme",
-      "changelog_location": "https://github.com/Keyfactor/signserver-ce/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/Keyfactor/signserver-ce/releases"
     },
     {
       "name": "SlimToolkit",
       "project_url": "https://slimtoolkit.org/",
       "repository": "https://github.com/slimtoolkit/slim",
       "compatibility_matrix_url": "https://github.com/slimtoolkit/slim/blob/master/README.md",
-      "changelog_location": "https://github.com/slimtoolkit/slim/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/slimtoolkit/slim/releases"
     },
     {
       "name": "Sonatype",
       "project_url": "https://www.sonatype.com",
       "repository": "https://github.com/sonatype/nexus-public",
       "compatibility_matrix_url": "https://github.com/sonatype/nexus-public#readme",
-      "changelog_location": "https://github.com/sonatype/nexus-public/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/sonatype/nexus-public/releases"
     },
     {
       "name": "Sonobuoy",
       "project_url": "https://sonobuoy.io",
       "repository": "https://github.com/vmware-tanzu/sonobuoy",
       "compatibility_matrix_url": "https://sonobuoy.io/docs/main/matrix/",
-      "changelog_location": "https://github.com/vmware-tanzu/sonobuoy/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/vmware-tanzu/sonobuoy/releases"
     },
     {
       "name": "StackRox",
       "project_url": "https://www.stackrox.io/",
       "repository": "https://github.com/stackrox/stackrox",
       "compatibility_matrix_url": "https://docs.openshift.com/acs/installing/acs-default-requirements.html",
-      "changelog_location": "https://github.com/stackrox/stackrox/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/stackrox/stackrox/releases"
     },
     {
       "name": "Teleport",
       "project_url": "https://goteleport.com",
       "repository": "https://github.com/gravitational/teleport",
       "compatibility_matrix_url": "https://goteleport.com/docs/reference/compatibility/",
-      "changelog_location": "https://github.com/gravitational/teleport/blob/master/CHANGELOG.md",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/gravitational/teleport/blob/master/CHANGELOG.md"
     },
     {
       "name": "Terrascan",
       "project_url": "https://www.tenable.com/products/tenable-cs",
       "repository": "https://github.com/tenable/terrascan",
       "compatibility_matrix_url": "https://runterrascan.io/docs/getting-started/",
-      "changelog_location": "https://github.com/tenable/terrascan/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/tenable/terrascan/releases"
     },
     {
       "name": "Tesseral",
       "project_url": "https://www.tesseral.com/",
       "repository": "https://github.com/tesseral-labs/tesseral",
       "compatibility_matrix_url": "https://github.com/tesseral-labs/tesseral#readme",
-      "changelog_location": "https://github.com/tesseral-labs/tesseral/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/tesseral-labs/tesseral/releases"
     },
     {
       "name": "Tetragon",
       "project_url": "https://github.com/cilium/tetragon",
       "repository": "https://github.com/cilium/tetragon",
       "compatibility_matrix_url": "https://tetragon.io/docs/installation/kubernetes/",
-      "changelog_location": "https://github.com/cilium/tetragon/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/cilium/tetragon/releases"
     },
     {
       "name": "The Update Framework (TUF)",
       "project_url": "https://theupdateframework.github.io/",
       "repository": "https://github.com/theupdateframework/python-tuf",
       "compatibility_matrix_url": "https://theupdateframework.readthedocs.io/en/latest/",
-      "changelog_location": "https://github.com/theupdateframework/python-tuf/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/theupdateframework/python-tuf/releases"
     },
     {
       "name": "ThreatMapper",
       "project_url": "https://deepfence.io/threatmapper/",
       "repository": "https://github.com/deepfence/ThreatMapper",
       "compatibility_matrix_url": "https://community.deepfence.io/threatmapper/docs/v2/kubernetes/",
-      "changelog_location": "https://github.com/deepfence/ThreatMapper/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/deepfence/ThreatMapper/releases"
     },
     {
       "name": "Tokenetes",
       "project_url": "https://tokenetes.io/",
       "repository": "https://github.com/tokenetes/tokenetes",
       "compatibility_matrix_url": "https://github.com/tokenetes/tokenetes#readme",
-      "changelog_location": "https://github.com/tokenetes/tokenetes/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/tokenetes/tokenetes/releases"
     },
     {
       "name": "Topaz",
       "project_url": "https://www.topaz.sh",
       "repository": "https://github.com/aserto-dev/topaz",
       "compatibility_matrix_url": "https://www.topaz.sh/docs/getting-started",
-      "changelog_location": "https://github.com/aserto-dev/topaz/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/aserto-dev/topaz/releases"
     },
     {
       "name": "Tracee",
       "project_url": "https://aquasecurity.github.io/tracee/latest/",
       "repository": "https://github.com/aquasecurity/tracee",
       "compatibility_matrix_url": "https://aquasecurity.github.io/tracee/latest/docs/install/prerequisites/",
-      "changelog_location": "https://github.com/aquasecurity/tracee/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/aquasecurity/tracee/releases"
     },
     {
       "name": "Trivy",
       "project_url": "https://trivy.dev",
       "repository": "https://github.com/aquasecurity/trivy",
       "compatibility_matrix_url": "https://aquasecurity.github.io/trivy/latest/docs/target/kubernetes/",
-      "changelog_location": "https://github.com/aquasecurity/trivy/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/aquasecurity/trivy/releases"
     },
     {
       "name": "Veinmind Tools",
       "project_url": "https://veinmind.chaitin.com/",
       "repository": "https://github.com/chaitin/veinmind-tools",
       "compatibility_matrix_url": "https://github.com/chaitin/veinmind-tools#readme",
-      "changelog_location": "https://github.com/chaitin/veinmind-tools/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/chaitin/veinmind-tools/releases"
     },
     {
       "name": "Zitadel",
       "project_url": "https://zitadel.com/",
       "repository": "https://github.com/zitadel/zitadel",
       "compatibility_matrix_url": "https://zitadel.com/docs/self-hosting/deploy/kubernetes",
-      "changelog_location": "https://github.com/zitadel/zitadel/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/zitadel/zitadel/releases"
     },
     {
       "name": "authentik",
       "project_url": "https://goauthentik.io/",
       "repository": "https://github.com/goauthentik/authentik",
       "compatibility_matrix_url": "https://docs.goauthentik.io/docs/installation/kubernetes",
-      "changelog_location": "https://github.com/goauthentik/authentik/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/goauthentik/authentik/releases"
     },
     {
       "name": "bpfman",
       "project_url": "https://bpfman.io/",
       "repository": "https://github.com/bpfman/bpfman",
       "compatibility_matrix_url": "https://bpfman.io/docs/getting-started/kubernetes-deployment/",
-      "changelog_location": "https://github.com/bpfman/bpfman/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/bpfman/bpfman/releases"
     },
     {
       "name": "cert-manager",
       "project_url": "https://cert-manager.io/",
       "repository": "https://github.com/cert-manager/cert-manager",
       "compatibility_matrix_url": "https://cert-manager.io/docs/releases/",
-      "changelog_location": "https://github.com/cert-manager/cert-manager/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/cert-manager/cert-manager/releases"
     },
     {
       "name": "external-secrets",
       "project_url": "https://external-secrets.io/",
       "repository": "https://github.com/external-secrets/external-secrets",
       "compatibility_matrix_url": "https://external-secrets.io/latest/introduction/stability-support/",
-      "changelog_location": "https://github.com/external-secrets/external-secrets/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/external-secrets/external-secrets/releases"
     },
     {
       "name": "in-toto",
       "project_url": "https://in-toto.io",
       "repository": "https://github.com/in-toto/in-toto",
       "compatibility_matrix_url": "https://github.com/in-toto/in-toto#requirements",
-      "changelog_location": "https://github.com/in-toto/in-toto/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/in-toto/in-toto/releases"
     },
     {
       "name": "kube-bench",
       "project_url": "https://github.com/aquasecurity/kube-bench",
       "repository": "https://github.com/aquasecurity/kube-bench",
       "compatibility_matrix_url": "https://github.com/aquasecurity/kube-bench/blob/main/docs/platforms.md",
-      "changelog_location": "https://github.com/aquasecurity/kube-bench/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/aquasecurity/kube-bench/releases"
     },
     {
       "name": "kube-hunter",
       "project_url": "https://github.com/aquasecurity/kube-hunter",
       "repository": "https://github.com/aquasecurity/kube-hunter",
       "compatibility_matrix_url": "https://github.com/aquasecurity/kube-hunter/blob/main/README.md",
-      "changelog_location": "https://github.com/aquasecurity/kube-hunter/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/aquasecurity/kube-hunter/releases"
     },
     {
       "name": "secureCodeBox",
       "project_url": "https://www.securecodebox.io/",
       "repository": "https://github.com/secureCodeBox/secureCodeBox",
       "compatibility_matrix_url": "https://www.securecodebox.io/docs/getting-started/installation",
-      "changelog_location": "https://github.com/secureCodeBox/secureCodeBox/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/secureCodeBox/secureCodeBox/releases"
     },
     {
       "name": "sigstore",
       "project_url": "https://www.sigstore.dev/",
       "repository": "https://github.com/sigstore/sigstore",
       "compatibility_matrix_url": "https://docs.sigstore.dev/system_config/installation/",
-      "changelog_location": "https://github.com/sigstore/sigstore/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/sigstore/sigstore/releases"
     },
     {
       "name": "sso",
       "project_url": "https://github.com/buzzfeed/sso",
       "repository": "https://github.com/buzzfeed/sso",
       "compatibility_matrix_url": "https://github.com/buzzfeed/sso#readme",
-      "changelog_location": "https://github.com/buzzfeed/sso/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/buzzfeed/sso/releases"
     },
     {
       "name": "vArmor",
       "project_url": "https://varmor.org",
       "repository": "https://github.com/bytedance/vArmor",
       "compatibility_matrix_url": "https://github.com/bytedance/vArmor/blob/main/README.md",
-      "changelog_location": "https://github.com/bytedance/vArmor/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/bytedance/vArmor/releases"
     },
     {
       "name": "Antrea",
       "project_url": "https://antrea.io/",
       "repository": "https://github.com/antrea-io/antrea",
       "compatibility_matrix_url": "https://antrea.io/docs/main/versioning/",
-      "changelog_location": "https://github.com/antrea-io/antrea/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/antrea-io/antrea/releases"
     },
     {
       "name": "CNI-Genie",
       "project_url": "https://cnigenie.netlify.app",
       "repository": "https://github.com/cni-genie/CNI-Genie",
       "compatibility_matrix_url": "https://github.com/cni-genie/CNI-Genie/blob/master/docs/GettingStarted.md",
-      "changelog_location": "https://github.com/cni-genie/CNI-Genie/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/cni-genie/CNI-Genie/releases"
     },
     {
       "name": "Cilium",
       "project_url": "https://cilium.io/",
       "repository": "https://github.com/cilium/cilium",
       "compatibility_matrix_url": "https://docs.cilium.io/en/stable/network/kubernetes/compatibility/",
-      "changelog_location": "https://github.com/cilium/cilium/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/cilium/cilium/releases"
     },
     {
       "name": "Container Network Interface (CNI)",
       "project_url": "https://www.cni.dev/",
       "repository": "https://github.com/containernetworking/cni",
       "compatibility_matrix_url": "https://github.com/containernetworking/cni/blob/main/SPEC.md",
-      "changelog_location": "https://github.com/containernetworking/cni/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/containernetworking/cni/releases"
     },
     {
       "name": "FabEdge",
       "project_url": "https://github.com/FabEdge/",
       "repository": "https://github.com/FabEdge/fabedge",
       "compatibility_matrix_url": "https://github.com/FabEdge/fabedge/blob/main/docs/install.md",
-      "changelog_location": "https://github.com/FabEdge/fabedge/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/FabEdge/fabedge/releases"
     },
     {
       "name": "Flannel",
       "project_url": "https://github.com/flannel-io/flannel",
       "repository": "https://github.com/flannel-io/flannel",
       "compatibility_matrix_url": "https://github.com/flannel-io/flannel/blob/master/README.md",
-      "changelog_location": "https://github.com/flannel-io/flannel/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/flannel-io/flannel/releases"
     },
     {
       "name": "Kilo",
       "project_url": "https://kilo.squat.ai",
       "repository": "https://github.com/squat/kilo",
       "compatibility_matrix_url": "https://github.com/squat/kilo/blob/main/README.md",
-      "changelog_location": "https://github.com/squat/kilo/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/squat/kilo/releases"
     },
     {
       "name": "Kube-OVN",
       "project_url": "https://kube-ovn.io",
       "repository": "https://github.com/kubeovn/kube-ovn",
       "compatibility_matrix_url": "https://kubeovn.github.io/docs/stable/start/prepare/",
-      "changelog_location": "https://github.com/kubeovn/kube-ovn/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubeovn/kube-ovn/releases"
     },
     {
       "name": "Kube-router",
       "project_url": "https://www.kube-router.io",
       "repository": "https://github.com/cloudnativelabs/kube-router",
       "compatibility_matrix_url": "https://github.com/cloudnativelabs/kube-router/blob/master/README.md",
-      "changelog_location": "https://github.com/cloudnativelabs/kube-router/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/cloudnativelabs/kube-router/releases"
     },
     {
       "name": "Ligato",
       "project_url": "https://ligato.io/",
       "repository": "https://github.com/ligato/vpp-agent",
       "compatibility_matrix_url": "https://docs.ligato.io/en/latest/user-guide/get-vpp-agent/",
-      "changelog_location": "https://github.com/ligato/vpp-agent/blob/master/CHANGELOG.md",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/ligato/vpp-agent/blob/master/CHANGELOG.md"
     },
     {
       "name": "Multus",
       "project_url": "https://networkbuilders.intel.com/intel-technologies/container-experience-kits",
       "repository": "https://github.com/k8snetworkplumbingwg/multus-cni",
       "compatibility_matrix_url": "https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/README.md",
-      "changelog_location": "https://github.com/k8snetworkplumbingwg/multus-cni/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/k8snetworkplumbingwg/multus-cni/releases"
     },
     {
       "name": "Network Service Mesh",
       "project_url": "https://networkservicemesh.io/",
       "repository": "https://github.com/networkservicemesh/api",
       "compatibility_matrix_url": "https://networkservicemesh.io/docs/concepts/features/",
-      "changelog_location": "https://github.com/networkservicemesh/deployments-k8s/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/networkservicemesh/deployments-k8s/releases"
     },
     {
       "name": "OVN-Kubernetes",
       "project_url": "https://ovn-kubernetes.io/",
       "repository": "https://github.com/ovn-kubernetes/ovn-kubernetes",
       "compatibility_matrix_url": "https://github.com/ovn-org/ovn-kubernetes/blob/master/README.md",
-      "changelog_location": "https://github.com/ovn-org/ovn-kubernetes/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/ovn-org/ovn-kubernetes/releases"
     },
     {
       "name": "Open vSwitch",
       "project_url": "https://www.openvswitch.org/",
       "repository": "https://github.com/openvswitch/ovs",
       "compatibility_matrix_url": "https://docs.openvswitch.org/en/latest/faq/releases/",
-      "changelog_location": "https://github.com/openvswitch/ovs/blob/main/NEWS",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/openvswitch/ovs/blob/main/NEWS"
     },
     {
       "name": "OpenSDN",
       "project_url": "https://opensdn.io",
       "repository": "https://github.com/OpenSDN-io",
       "compatibility_matrix_url": "https://github.com/OpenSDN-io/docs/wiki",
-      "changelog_location": "https://github.com/OpenSDN-io/tf-controller/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/OpenSDN-io/tf-controller/releases"
     },
     {
       "name": "Project Calico",
       "project_url": "https://www.tigera.io/project-calico",
       "repository": "https://github.com/projectcalico/calico",
       "compatibility_matrix_url": "https://docs.tigera.io/calico/latest/getting-started/kubernetes/requirements",
-      "changelog_location": "https://github.com/projectcalico/calico/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/projectcalico/calico/releases"
     },
     {
       "name": "Spiderpool",
       "project_url": "https://spidernet-io.github.io/spiderpool/",
       "repository": "https://github.com/spidernet-io/spiderpool",
       "compatibility_matrix_url": "https://spidernet-io.github.io/spiderpool/usage/install/",
-      "changelog_location": "https://github.com/spidernet-io/spiderpool/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/spidernet-io/spiderpool/releases"
     },
     {
       "name": "Submariner",
       "project_url": "https://submariner.io",
       "repository": "https://github.com/submariner-io/submariner",
       "compatibility_matrix_url": "https://submariner.io/getting-started/architecture/prerequisites/",
-      "changelog_location": "https://github.com/submariner-io/submariner/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/submariner-io/submariner/releases"
     },
     {
       "name": "kube-vip",
       "project_url": "https://kube-vip.io",
       "repository": "https://github.com/kube-vip/kube-vip",
       "compatibility_matrix_url": "https://kube-vip.io/docs/installation/",
-      "changelog_location": "https://github.com/kube-vip/kube-vip/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/kube-vip/kube-vip/releases"
     },
     {
       "name": "Alluxio",
       "project_url": "https://www.alluxio.io/",
       "repository": "https://github.com/alluxio/alluxio",
       "compatibility_matrix_url": "https://docs.alluxio.io/kubernetes/user/stable/en/Overview.html",
-      "changelog_location": "https://github.com/alluxio/alluxio/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/alluxio/alluxio/releases"
     },
     {
       "name": "Carina",
       "project_url": "https://carina-io.github.io/",
       "repository": "https://github.com/carina-io/carina",
       "compatibility_matrix_url": "https://github.com/carina-io/carina/blob/main/docs/manual/installation.md",
-      "changelog_location": "https://github.com/carina-io/carina/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/carina-io/carina/releases"
     },
     {
       "name": "Ceph",
       "project_url": "https://ceph.io/en",
       "repository": "https://github.com/ceph/ceph",
       "compatibility_matrix_url": "https://rook.io/docs/rook/latest/Getting-Started/Prerequisites/prerequisites/",
-      "changelog_location": "https://github.com/ceph/ceph/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/ceph/ceph/releases"
     },
     {
       "name": "Container Storage Interface (CSI)",
       "project_url": "https://github.com/container-storage-interface",
       "repository": "https://github.com/container-storage-interface/spec",
       "compatibility_matrix_url": "https://kubernetes-csi.github.io/docs/#kubernetes-releases",
-      "changelog_location": "https://github.com/container-storage-interface/spec/blob/master/CHANGELOG.md",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/container-storage-interface/spec/blob/master/CHANGELOG.md"
     },
     {
       "name": "CubeFS",
       "project_url": "https://cubefs.io/",
       "repository": "https://github.com/cubeFS/cubefs",
       "compatibility_matrix_url": "https://cubefs.io/docs/master/deploy/k8s.html",
-      "changelog_location": "https://github.com/cubefs/cubefs/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/cubefs/cubefs/releases"
     },
     {
       "name": "Curve",
       "project_url": "https://www.opencurve.io/",
       "repository": "https://github.com/opencurve/curve",
       "compatibility_matrix_url": "https://github.com/opencurve/curve/blob/master/docs/cn/deploy.md",
-      "changelog_location": "https://github.com/opencurve/curve/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/opencurve/curve/releases"
     },
     {
       "name": "DatenLord",
       "project_url": "https://datenlord.github.io/",
       "repository": "https://github.com/datenlord/datenlord",
       "compatibility_matrix_url": "https://github.com/datenlord/datenlord/blob/master/README.md",
-      "changelog_location": "https://github.com/datenlord/datenlord/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/datenlord/datenlord/releases"
     },
     {
       "name": "Gluster",
       "project_url": "https://www.gluster.org/",
       "repository": "https://github.com/gluster/glusterfs",
       "compatibility_matrix_url": "https://docs.gluster.org/en/latest/Install-Guide/Overview/",
-      "changelog_location": "https://github.com/gluster/glusterfs/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/gluster/glusterfs/releases"
     },
     {
       "name": "HwameiStor",
       "project_url": "https://hwameistor.io/",
       "repository": "https://github.com/hwameistor/hwameistor",
       "compatibility_matrix_url": "https://hwameistor.io/docs/intro/install",
-      "changelog_location": "https://github.com/hwameistor/hwameistor/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/hwameistor/hwameistor/releases"
     },
     {
       "name": "JuiceFS",
       "project_url": "https://juicefs.com/",
       "repository": "https://github.com/juicedata/juicefs",
       "compatibility_matrix_url": "https://juicefs.com/docs/csi/introduction/#kubernetes-version-compatibility",
-      "changelog_location": "https://github.com/juicedata/juicefs/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/juicedata/juicefs/releases"
     },
     {
       "name": "K8up",
       "project_url": "https://www.k8up.io/",
       "repository": "https://github.com/k8up-io/k8up",
       "compatibility_matrix_url": "https://k8up.io/k8up/references/operator-config-reference.html",
-      "changelog_location": "https://github.com/k8up-io/k8up/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/k8up-io/k8up/releases"
     },
     {
       "name": "Kanister",
       "project_url": "https://kanister.io",
       "repository": "https://github.com/kanisterio/kanister",
       "compatibility_matrix_url": "https://docs.kanister.io/install.html",
-      "changelog_location": "https://github.com/kanisterio/kanister/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kanisterio/kanister/releases"
     },
     {
       "name": "LINSTOR",
       "project_url": "https://www.linbit.com/linstor/",
       "repository": "https://github.com/LINBIT/linstor-server",
       "compatibility_matrix_url": "https://linbit.com/drbd-user-guide/linstor-guide-1_0-en/#s-kubernetes-compatibility",
-      "changelog_location": "https://github.com/LINBIT/linstor-server/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/LINBIT/linstor-server/releases"
     },
     {
       "name": "Longhorn",
       "project_url": "https://longhorn.io/",
       "repository": "https://github.com/longhorn/longhorn",
       "compatibility_matrix_url": "https://longhorn.io/docs/latest/best-practices/#kubernetes-version",
-      "changelog_location": "https://github.com/longhorn/longhorn/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/longhorn/longhorn/releases"
     },
     {
       "name": "MinIO",
       "project_url": "https://min.io/",
       "repository": "https://github.com/minio/minio",
       "compatibility_matrix_url": "https://min.io/docs/minio/kubernetes/upstream/operations/installation.html",
-      "changelog_location": "https://github.com/minio/minio/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/minio/minio/releases"
     },
     {
       "name": "MooseFS",
       "project_url": "https://moosefs.com/",
       "repository": "https://github.com/moosefs/moosefs",
       "compatibility_matrix_url": "https://moosefs.com/documentation/",
-      "changelog_location": "https://github.com/moosefs/moosefs/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/moosefs/moosefs/releases"
     },
     {
       "name": "ORAS",
       "project_url": "https://oras.land/",
       "repository": "https://github.com/oras-project/oras",
       "compatibility_matrix_url": "https://oras.land/docs/compatible_oci_registries",
-      "changelog_location": "https://github.com/oras-project/oras/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/oras-project/oras/releases"
     },
     {
       "name": "OpenEBS",
       "project_url": "https://www.openebs.io/",
       "repository": "https://github.com/openebs/openebs",
       "compatibility_matrix_url": "https://openebs.io/docs/quickstart-guide/installation#prerequisites",
-      "changelog_location": "https://github.com/openebs/openebs/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/openebs/openebs/releases"
     },
     {
       "name": "OpenIO",
       "project_url": "https://docs.openio.io/",
       "repository": "https://github.com/open-io/oio-sds",
       "compatibility_matrix_url": "https://docs.openio.io/latest/source/sandbox-guide/installation.html",
-      "changelog_location": "https://github.com/open-io/oio-sds/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/open-io/oio-sds/releases"
     },
     {
       "name": "Piraeus Datastore",
       "project_url": "https://piraeus.io/",
       "repository": "https://github.com/piraeusdatastore/piraeus-operator",
       "compatibility_matrix_url": "https://github.com/piraeusdatastore/piraeus-operator/blob/v2/docs/README.md",
-      "changelog_location": "https://github.com/piraeusdatastore/piraeus-operator/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/piraeusdatastore/piraeus-operator/releases"
     },
     {
       "name": "Rook",
       "project_url": "https://rook.io/",
       "repository": "https://github.com/rook/rook",
       "compatibility_matrix_url": "https://rook.io/docs/rook/latest/Getting-Started/Prerequisites/prerequisites/#kubernetes-version",
-      "changelog_location": "https://github.com/rook/rook/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/rook/rook/releases"
     },
     {
       "name": "Soda Foundation",
       "project_url": "https://sodafoundation.io/wp-content/uploads/2021/03/cn.png",
       "repository": "https://github.com/sodafoundation/api",
       "compatibility_matrix_url": "https://docs.sodafoundation.io/soda-gettingstarted/installation-using-ansible/#supported-os-and-kubernetes-versions",
-      "changelog_location": "https://github.com/sodafoundation/api/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/sodafoundation/api/releases"
     },
     {
       "name": "Stash by AppsCode",
       "project_url": "https://stash.run",
       "repository": "https://github.com/stashed/stash",
       "compatibility_matrix_url": "https://stash.run/docs/latest/setup/install/stash/#prerequisites",
-      "changelog_location": "https://github.com/stashed/stash/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/stashed/stash/releases"
     },
     {
       "name": "Swift",
       "project_url": "https://docs.openstack.org/swift/latest/",
       "repository": "https://github.com/openstack/swift",
       "compatibility_matrix_url": "https://github.com/openstack/swift#readme",
-      "changelog_location": "https://github.com/openstack/swift/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/openstack/swift/releases"
     },
     {
       "name": "Triton Object Storage",
       "project_url": "https://www.tritondatacenter.com/triton/object-storage",
       "repository": "https://github.com/TritonDataCenter/manta",
       "compatibility_matrix_url": "https://github.com/TritonDataCenter/manta#readme",
-      "changelog_location": "https://github.com/TritonDataCenter/manta/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/TritonDataCenter/manta/releases"
     },
     {
       "name": "Velero",
       "project_url": "https://velero.io",
       "repository": "https://github.com/vmware-tanzu/velero",
       "compatibility_matrix_url": "https://velero.io/docs/main/basic-install/#prerequisites",
-      "changelog_location": "https://github.com/vmware-tanzu/velero/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/vmware-tanzu/velero/releases"
     },
     {
       "name": "Vineyard",
       "project_url": "https://v6d.io",
       "repository": "https://github.com/v6d-io/v6d",
       "compatibility_matrix_url": "https://v6d.io/notes/getting-started.html#prerequisites",
-      "changelog_location": "https://github.com/v6d-io/v6d/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/v6d-io/v6d/releases"
     },
     {
       "name": "Zenko",
       "project_url": "https://www.zenko.io",
       "repository": "https://github.com/scality/zenko",
       "compatibility_matrix_url": "https://zenko.io/docs/installation/prerequisites/",
-      "changelog_location": "https://github.com/scality/zenko/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/scality/zenko/releases"
     },
     {
       "name": "Kubelogin",
       "project_url": "https://github.com/int128/kubelogin",
       "repository": "https://github.com/int128/kubelogin",
       "compatibility_matrix_url": "https://github.com/int128/kubelogin#getting-started",
-      "changelog_location": "https://github.com/int128/kubelogin/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/int128/kubelogin/releases"
     },
     {
       "name": "Pinniped",
       "project_url": "https://pinniped.dev/",
       "repository": "https://github.com/vmware-tanzu/pinniped",
       "compatibility_matrix_url": "https://pinniped.dev/docs/reference/supported-clusters/",
-      "changelog_location": "https://github.com/vmware-tanzu/pinniped/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/vmware-tanzu/pinniped/releases"
     },
     {
       "name": "kube-score",
       "project_url": "https://kube-score.com/",
       "repository": "https://github.com/zegl/kube-score",
       "compatibility_matrix_url": "https://github.com/zegl/kube-score#installation",
-      "changelog_location": "https://github.com/zegl/kube-score/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/zegl/kube-score/releases"
     },
     {
       "name": "step-ca",
       "project_url": "https://smallstep.com/docs/step-ca/",
       "repository": "https://github.com/smallstep/certificates",
       "compatibility_matrix_url": "https://smallstep.com/docs/step-ca/installation/",
-      "changelog_location": "https://github.com/smallstep/certificates/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/smallstep/certificates/releases"
     },
     {
       "name": "cert-manager approver-policy",
       "project_url": "https://cert-manager.io/docs/policy/approval/approver-policy/",
       "repository": "https://github.com/cert-manager/approver-policy",
       "compatibility_matrix_url": "https://cert-manager.io/docs/policy/approval/approver-policy/#installation",
-      "changelog_location": "https://github.com/cert-manager/approver-policy/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/cert-manager/approver-policy/releases"
     },
     {
       "name": "Kubeaudit",
       "project_url": "https://github.com/Shopify/kubeaudit",
       "repository": "https://github.com/Shopify/kubeaudit",
       "compatibility_matrix_url": "https://github.com/Shopify/kubeaudit#installation",
-      "changelog_location": "https://github.com/Shopify/kubeaudit/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/Shopify/kubeaudit/releases"
     },
     {
       "name": "Anchore Engine",
       "project_url": "https://anchore.com/",
       "repository": "https://github.com/anchore/anchore-engine",
       "compatibility_matrix_url": "https://docs.anchore.com/current/docs/deployment/kubernetes/",
-      "changelog_location": "https://github.com/anchore/anchore-engine/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/anchore/anchore-engine/releases"
     },
     {
       "name": "Snyk Container",
       "project_url": "https://snyk.io/product/container-vulnerability-management/",
       "repository": "https://github.com/snyk/cli",
       "compatibility_matrix_url": "https://docs.snyk.io/scan-using-snyk/snyk-container/kubernetes-integration/overview-of-the-kubernetes-integration/supported-container-registries",
-      "changelog_location": "https://github.com/snyk/cli/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/snyk/cli/releases"
     },
     {
       "name": "Cosign",
       "project_url": "https://docs.sigstore.dev/cosign/overview/",
       "repository": "https://github.com/sigstore/cosign",
       "compatibility_matrix_url": "https://docs.sigstore.dev/cosign/system_config/installation/",
-      "changelog_location": "https://github.com/sigstore/cosign/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/sigstore/cosign/releases"
     },
     {
       "name": "Trivy Operator",
       "project_url": "https://aquasecurity.github.io/trivy-operator/",
       "repository": "https://github.com/aquasecurity/trivy-operator",
       "compatibility_matrix_url": "https://aquasecurity.github.io/trivy-operator/latest/getting-started/installation/helm/",
-      "changelog_location": "https://github.com/aquasecurity/trivy-operator/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/aquasecurity/trivy-operator/releases"
     },
     {
       "name": "Connaisseur",
       "project_url": "https://sse-secure-systems.github.io/connaisseur/",
       "repository": "https://github.com/sse-secure-systems/connaisseur",
       "compatibility_matrix_url": "https://sse-secure-systems.github.io/connaisseur/latest/getting_started/",
-      "changelog_location": "https://github.com/sse-secure-systems/connaisseur/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/sse-secure-systems/connaisseur/releases"
     },
     {
       "name": "Portieris",
       "project_url": "https://github.com/IBM/portieris",
       "repository": "https://github.com/IBM/portieris",
       "compatibility_matrix_url": "https://github.com/IBM/portieris#prerequisites",
-      "changelog_location": "https://github.com/IBM/portieris/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/IBM/portieris/releases"
     },
     {
       "name": "Kubeconform",
       "project_url": "https://github.com/yannh/kubeconform",
       "repository": "https://github.com/yannh/kubeconform",
       "compatibility_matrix_url": "https://github.com/yannh/kubeconform#usage",
-      "changelog_location": "https://github.com/yannh/kubeconform/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/yannh/kubeconform/releases"
     },
     {
       "name": "Kubeval",
       "project_url": "https://www.kubeval.com/",
       "repository": "https://github.com/instrumenta/kubeval",
       "compatibility_matrix_url": "https://www.kubeval.com/installation/",
-      "changelog_location": "https://github.com/instrumenta/kubeval/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/instrumenta/kubeval/releases"
     },
     {
       "name": "Datree",
       "project_url": "https://datree.io/",
       "repository": "https://github.com/datreeio/datree",
       "compatibility_matrix_url": "https://hub.datree.io/setup/install",
-      "changelog_location": "https://github.com/datreeio/datree/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/datreeio/datree/releases"
     },
     {
       "name": "Kyverno Policy Reporter",
       "project_url": "https://kyverno.github.io/policy-reporter/",
       "repository": "https://github.com/kyverno/policy-reporter",
       "compatibility_matrix_url": "https://kyverno.github.io/policy-reporter/getting-started/installation/",
-      "changelog_location": "https://github.com/kyverno/policy-reporter/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kyverno/policy-reporter/releases"
     },
     {
       "name": "Conftest",
       "project_url": "https://www.conftest.dev/",
       "repository": "https://github.com/open-policy-agent/conftest",
       "compatibility_matrix_url": "https://www.conftest.dev/install/",
-      "changelog_location": "https://github.com/open-policy-agent/conftest/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/open-policy-agent/conftest/releases"
     },
     {
       "name": "Syft",
       "project_url": "https://github.com/anchore/syft",
       "repository": "https://github.com/anchore/syft",
       "compatibility_matrix_url": "https://github.com/anchore/syft#supported-ecosystems",
-      "changelog_location": "https://github.com/anchore/syft/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/anchore/syft/releases"
     },
     {
       "name": "AWS Secrets Manager CSI Driver",
       "project_url": "https://docs.aws.amazon.com/secretsmanager/latest/userguide/integrating_csi_driver.html",
       "repository": "https://github.com/aws/secrets-store-csi-driver-provider-aws",
       "compatibility_matrix_url": "https://github.com/aws/secrets-store-csi-driver-provider-aws#compatibility",
-      "changelog_location": "https://github.com/aws/secrets-store-csi-driver-provider-aws/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/aws/secrets-store-csi-driver-provider-aws/releases"
     },
     {
       "name": "Azure Key Vault Provider for Secrets Store CSI Driver",
       "project_url": "https://azure.github.io/secrets-store-csi-driver-provider-azure/",
       "repository": "https://github.com/Azure/secrets-store-csi-driver-provider-azure",
       "compatibility_matrix_url": "https://azure.github.io/secrets-store-csi-driver-provider-azure/docs/getting-started/installation/#prerequisites",
-      "changelog_location": "https://github.com/Azure/secrets-store-csi-driver-provider-azure/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/Azure/secrets-store-csi-driver-provider-azure/releases"
     },
     {
       "name": "GCP Secret Manager Provider for Secrets Store CSI Driver",
       "project_url": "https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp",
       "repository": "https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp",
       "compatibility_matrix_url": "https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp#prerequisites",
-      "changelog_location": "https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/releases"
     },
     {
       "name": "HashiCorp Vault",
       "project_url": "https://www.vaultproject.io/",
       "repository": "https://github.com/hashicorp/vault",
       "compatibility_matrix_url": "https://developer.hashicorp.com/vault/docs/deploy/kubernetes/helm",
-      "changelog_location": "https://github.com/hashicorp/vault/blob/main/CHANGELOG.md",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/hashicorp/vault/blob/main/CHANGELOG.md"
     },
     {
       "name": "Secrets Store CSI Driver",
       "project_url": "https://secrets-store-csi-driver.sigs.k8s.io/",
       "repository": "https://github.com/kubernetes-sigs/secrets-store-csi-driver",
       "compatibility_matrix_url": "https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation",
-      "changelog_location": "https://github.com/kubernetes-sigs/secrets-store-csi-driver/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubernetes-sigs/secrets-store-csi-driver/releases"
     },
     {
       "name": "Grype",
       "project_url": "https://github.com/anchore/grype",
       "repository": "https://github.com/anchore/grype",
       "compatibility_matrix_url": "https://github.com/anchore/grype#supported-sources",
-      "changelog_location": "https://github.com/anchore/grype/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/anchore/grype/releases"
     },
     {
       "name": "Authelia",
       "project_url": "https://www.authelia.com/",
       "repository": "https://github.com/authelia/authelia",
       "compatibility_matrix_url": "https://www.authelia.com/integration/kubernetes/introduction/",
-      "changelog_location": "https://github.com/authelia/authelia/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/authelia/authelia/releases"
     },
     {
       "name": "Ory Hydra",
       "project_url": "https://www.ory.sh/hydra/",
       "repository": "https://github.com/ory/hydra",
       "compatibility_matrix_url": "https://www.ory.sh/docs/hydra/self-hosted/kubernetes-helm-chart",
-      "changelog_location": "https://github.com/ory/hydra/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/ory/hydra/releases"
     },
     {
       "name": "Vault Agent Injector",
       "project_url": "https://developer.hashicorp.com/vault/docs/platform/k8s/injector",
       "repository": "https://github.com/hashicorp/vault-k8s",
       "compatibility_matrix_url": "https://developer.hashicorp.com/vault/docs/platform/k8s/injector/installation",
-      "changelog_location": "https://github.com/hashicorp/vault-k8s/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/hashicorp/vault-k8s/releases"
     },
     {
       "name": "Mondoo",
       "project_url": "https://mondoo.com/",
       "repository": "https://github.com/mondoohq/mondoo-operator",
       "compatibility_matrix_url": "https://mondoo.com/docs/cnspec/cloud/k8s/",
-      "changelog_location": "https://github.com/mondoohq/mondoo-operator/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/mondoohq/mondoo-operator/releases"
     },
     {
       "name": "Kube-linter",
       "project_url": "https://github.com/stackrox/kube-linter",
       "repository": "https://github.com/stackrox/kube-linter",
       "compatibility_matrix_url": "https://github.com/stackrox/kube-linter#readme",
-      "changelog_location": "https://github.com/stackrox/kube-linter/releases",
-      "upgrade_path_type": "Manual-manifest"
+      "changelog_location": "https://github.com/stackrox/kube-linter/releases"
     },
     {
       "name": "Snyk Controller",
       "project_url": "https://docs.snyk.io/products/snyk-container/kubernetes-integration/install-the-snyk-controller",
       "repository": "https://github.com/snyk/kubernetes-monitor",
       "compatibility_matrix_url": "https://docs.snyk.io/products/snyk-container/kubernetes-integration/overview-of-kubernetes-integration/prerequisites",
-      "changelog_location": "https://github.com/snyk/kubernetes-monitor/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/snyk/kubernetes-monitor/releases"
     },
     {
       "name": "SPIFFE / SPIRE",
       "project_url": "https://spiffe.io/",
       "repository": "https://github.com/spiffe/spire",
       "compatibility_matrix_url": "https://spiffe.io/docs/latest/deploying/install-server/",
-      "changelog_location": "https://github.com/spiffe/spire/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/spiffe/spire/releases"
     },
     {
       "name": "Fission",
       "project_url": "https://fission.io/",
       "repository": "https://github.com/fission/fission",
       "compatibility_matrix_url": "https://fission.io/docs/installation/",
-      "changelog_location": "https://github.com/fission/fission/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/fission/fission/releases"
     },
     {
       "name": "Nuclio",
       "project_url": "https://nuclio.io/",
       "repository": "https://github.com/nuclio/nuclio",
       "compatibility_matrix_url": "https://nuclio.io/docs/latest/setup/k8s/getting-started-k8s/",
-      "changelog_location": "https://github.com/nuclio/nuclio/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/nuclio/nuclio/releases"
     },
     {
       "name": "OpenFaaS",
       "project_url": "https://www.openfaas.com/",
       "repository": "https://github.com/openfaas/faas",
       "compatibility_matrix_url": "https://docs.openfaas.com/deployment/kubernetes/",
-      "changelog_location": "https://github.com/openfaas/faas/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/openfaas/faas/releases"
     },
     {
       "name": "Skupper",
       "project_url": "https://skupper.io/",
       "repository": "https://github.com/skupperproject/skupper",
       "compatibility_matrix_url": "https://skupper.io/releases/",
-      "changelog_location": "https://github.com/skupperproject/skupper/releases",
-      "upgrade_path_type": "Operator-managed"
+      "changelog_location": "https://github.com/skupperproject/skupper/releases"
     },
     {
       "name": "Cilium Service Mesh",
       "project_url": "https://cilium.io/",
       "repository": "https://github.com/cilium/cilium",
       "compatibility_matrix_url": "https://docs.cilium.io/en/stable/network/kubernetes/requirements/",
-      "changelog_location": "https://github.com/cilium/cilium/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/cilium/cilium/releases"
     },
     {
       "name": "Minio Operator",
       "project_url": "https://min.io/docs/minio/kubernetes/upstream/",
       "repository": "https://github.com/minio/operator",
       "compatibility_matrix_url": "https://min.io/docs/minio/kubernetes/upstream/operations/install-deploy-manage/deploy-operator-helm.html",
-      "changelog_location": "https://github.com/minio/operator/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/minio/operator/releases"
     },
     {
       "name": "Witness",
       "project_url": "https://witness.dev/",
       "repository": "https://github.com/in-toto/witness",
       "compatibility_matrix_url": "https://github.com/in-toto/witness#installation",
-      "changelog_location": "https://github.com/in-toto/witness/releases",
-      "upgrade_path_type": "CLI-tool"
+      "changelog_location": "https://github.com/in-toto/witness/releases"
     },
     {
       "name": "Fulcio",
       "project_url": "https://docs.sigstore.dev/certificate_authority/overview/",
       "repository": "https://github.com/sigstore/fulcio",
       "compatibility_matrix_url": "https://docs.sigstore.dev/certificate_authority/installation/",
-      "changelog_location": "https://github.com/sigstore/fulcio/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/sigstore/fulcio/releases"
     },
     {
       "name": "GUAC",
       "project_url": "https://guac.sh/",
       "repository": "https://github.com/guacsec/guac",
       "compatibility_matrix_url": "https://docs.guac.sh/setup/",
-      "changelog_location": "https://github.com/guacsec/guac/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/guacsec/guac/releases"
     },
     {
       "name": "Rekor",
       "project_url": "https://docs.sigstore.dev/logging/overview/",
       "repository": "https://github.com/sigstore/rekor",
       "compatibility_matrix_url": "https://docs.sigstore.dev/logging/installation/",
-      "changelog_location": "https://github.com/sigstore/rekor/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/sigstore/rekor/releases"
     },
     {
       "name": "Microcks",
       "project_url": "https://microcks.io/",
       "repository": "https://github.com/microcks/microcks",
       "compatibility_matrix_url": "https://microcks.io/documentation/installing/kubernetes/",
-      "changelog_location": "https://github.com/microcks/microcks/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/microcks/microcks/releases"
     },
     {
       "name": "Testkube",
       "project_url": "https://testkube.io/",
       "repository": "https://github.com/kubeshop/testkube",
       "compatibility_matrix_url": "https://docs.testkube.io/articles/install/overview",
-      "changelog_location": "https://github.com/kubeshop/testkube/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/kubeshop/testkube/releases"
     },
     {
       "name": "kube-proxy",
       "project_url": "https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/",
       "repository": "https://github.com/kubernetes/kubernetes",
       "compatibility_matrix_url": "https://kubernetes.io/releases/",
-      "changelog_location": "https://github.com/kubernetes/kubernetes/releases",
-      "upgrade_path_type": "Cluster-managed"
+      "changelog_location": "https://github.com/kubernetes/kubernetes/releases"
     },
     {
       "name": "Prometheus Node Exporter",
       "project_url": "https://prometheus.io/docs/guides/node-exporter/",
       "repository": "https://github.com/prometheus/node_exporter",
       "compatibility_matrix_url": "https://github.com/prometheus/node_exporter#readme",
-      "changelog_location": "https://github.com/prometheus/node_exporter/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/prometheus/node_exporter/releases"
     },
     {
       "name": "Redis",
       "project_url": "https://redis.io/",
       "repository": "https://github.com/redis/redis",
       "compatibility_matrix_url": "https://github.com/bitnami/charts/tree/main/bitnami/redis",
-      "changelog_location": "https://github.com/redis/redis/releases",
-      "upgrade_path_type": "Helm-driven"
+      "changelog_location": "https://github.com/redis/redis/releases"
     },
     {
       "name": "AWS Network Policy Agent",
       "project_url": "https://github.com/aws/aws-network-policy-agent",
       "repository": "https://github.com/aws/aws-network-policy-agent",
       "compatibility_matrix_url": "https://github.com/aws/aws-network-policy-agent#readme",
-      "changelog_location": "https://github.com/aws/aws-network-policy-agent/releases",
-      "upgrade_path_type": "Cluster-managed"
+      "changelog_location": "https://github.com/aws/aws-network-policy-agent/releases"
     }
   ],
   "metadata": {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -37,6 +37,7 @@ func Run(ctx context.Context, apiKey, model, namespace, k8sVersionOverride, addo
 	if err != nil {
 		return fmt.Errorf("loading addon database: %w", err)
 	}
+	addonMatcher := addon.NewMatcher(addonDB)
 
 	// Phase 1: Deterministic data collection (no LLM involved)
 	k8sVersion := k8sVersionOverride
@@ -79,7 +80,7 @@ func Run(ctx context.Context, apiKey, model, namespace, k8sVersionOverride, addo
 	}
 	bestByName := make(map[string]enrichedEntry)
 	for _, a := range detected {
-		matches := addon.LookupAddon(a.Name, addonDB)
+		matches := addonMatcher.Match(a.Name)
 		if len(matches) == 0 {
 			continue
 		}


### PR DESCRIPTION
## Summary
- remove the unused `upgrade_path_type` field from the addon schema and embedded addon database
- optimize addon lookup performance by introducing a reusable matcher and using it in the analysis pipeline
- keep core addon discovery behavior (including HelmRelease/Argo Application paths) while updating docs/tests to match the lean schema

## Test plan
- [x] `go vet ./...`
- [x] `go test -race ./...`

Made with [Cursor](https://cursor.com)