### PR TITLE
fix: unblock main workflows for release and tap checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,21 @@ jobs:
     if: github.event_name == 'push'
     runs-on: macos-latest
     steps:
-      - name: Tap and install formula
+      - name: Tap repository
+        run: brew tap qbandev/tap
+      - name: Check formula availability
+        id: homebrew_formula
         run: |
-          brew tap qbandev/tap
+          if brew info qbandev/tap/kaddons >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Formula qbandev/tap/kaddons not found yet; skipping install verification."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Tap and install formula
+        if: steps.homebrew_formula.outputs.exists == 'true'
+        run: |
           brew install qbandev/tap/kaddons
       - name: Verify Homebrew-installed binary
+        if: steps.homebrew_formula.outputs.exists == 'true'
         run: kaddons --version

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,3 +19,5 @@ jobs:
     steps:
       - name: Run release-please
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -11,7 +11,6 @@ on:
 permissions:
   actions: read
   contents: read
-  id-token: write
 
 concurrency:
   group: scorecards-${{ github.workflow }}-${{ github.ref }}
@@ -21,6 +20,11 @@ jobs:
   analysis:
     name: Scorecards analysis
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+      id-token: write
     steps:
       - name: Run scorecards analysis
         uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0


### PR DESCRIPTION
## Summary
- Add `RELEASE_PLEASE_TOKEN` fallback in `release-please.yml` so release-please can open/update release PRs when default token permissions are restricted.
- Scope Scorecards write permissions at the job level (`id-token: write`, `security-events: write`) while keeping top-level permissions read-only to satisfy workflow verification.
- Make Homebrew tap install verification in `ci.yml` resilient by checking formula existence first and skipping with a warning until `qbandev/tap/kaddons` is published.

## Test plan
- [x] Confirm branch is clean and pushed.
- [x] Verify workflow file diffs are limited to the three targeted workflows.
- [ ] Let GitHub Actions run on this PR and verify checks complete.

Made with [Cursor](https://cursor.com)