### PR TITLE
fix: use supported Homebrew directory key in GoReleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,7 +51,7 @@ brews:
     homepage: "https://github.com/qbandev/kaddons"
     description: "Kubernetes addon compatibility checker powered by Gemini AI"
     license: "MIT"
-    folder: Formula
+    directory: Formula
     dependencies:
       - name: kubernetes-cli
     test: |


### PR DESCRIPTION
## Summary
- Replace invalid `folder` key with supported `directory` key in `.goreleaser.yaml` Homebrew config.
- Unblocks GoReleaser Homebrew formula generation/publish step that failed in the `v0.2.0` release run.

## Test plan
- [x] Validate minimal config-only diff.
- [ ] Let CI checks pass.
- [ ] Merge and verify release + Homebrew formula availability.

Made with [Cursor](https://cursor.com)