### PR TITLE
fix: let goreleaser own GitHub release creation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,3 +21,4 @@ jobs:
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
+          skip-github-release: true


### PR DESCRIPTION
## Summary
- Set `skip-github-release: true` in `release-please.yml`.
- Prevents release-please from creating immutable GitHub releases before GoReleaser uploads assets.
- Keeps tag creation in release-please while delegating release asset publishing to `release.yml`.

## Test plan
- [ ] CI checks on this PR
- [ ] Merge and validate next release publish path

Made with [Cursor](https://cursor.com)