### PR TITLE
fix: remove skip-github-release to restore tag creation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,4 +21,3 @@ jobs:
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
-          skip-github-release: true


### PR DESCRIPTION
## Summary

- Remove `skip-github-release: true` from `release-please.yml` — this flag skips the **entire release phase** (including tag creation), not just the GitHub release object
- Without tags, `release.yml` (GoReleaser) never triggers, so no binaries or Homebrew updates are published
- GoReleaser already has `mode: keep-existing` in `.goreleaser.yaml` (line 30), so it safely coexists with release-please's GitHub releases

## Root cause

PR #17 added `skip-github-release: true` intending to let GoReleaser own release creation. However, this flag prevents release-please from entering the "Building releases" phase entirely — no tag, no release, nothing for GoReleaser to trigger on.

## Test plan
- [ ] Merge this PR → release-please runs with the fix
- [ ] Verify release-please enters "Building releases" phase in workflow logs
- [ ] Next release PR merge should create a tag and trigger GoReleaser

🤖 Generated with [Claude Code](https://claude.com/claude-code)