### PR TITLE
fix: document release immutability requirement

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -107,6 +107,8 @@ release-please accumulates changes into a release PR. When the release PR is mer
 `RELEASE_PLEASE_TOKEN` (PAT) is required so release PRs trigger CI checks.
 `HOMEBREW_TAP_TOKEN` (PAT) is required because Homebrew publishing writes formula updates to the external `qbandev/homebrew-tap` repository.
 
+**Release immutability** is enabled on this repository. Once a release is published, its tag and assets cannot be modified or reused — even if the release is later deleted.
+
 ### Changelog
 
 release-please generates and maintains `CHANGELOG.md` from conventional commit messages. GoReleaser's changelog is disabled to avoid duplication.


### PR DESCRIPTION
## Summary

- Add note about release immutability being enabled on this repository
- This setting prevents tag/asset reuse after a release is published (even if deleted)
- Triggers v0.3.2 release cycle (v0.3.1 tag is permanently reserved due to immutability)

## Test plan

- [ ] CI passes
- [ ] After merge, release-please creates v0.3.2 release PR
- [ ] After release PR merge, GoReleaser builds + publishes binaries and Homebrew formula

🤖 Generated with [Claude Code](https://claude.com/claude-code)